### PR TITLE
Change pr-labeler workflow trigger to pull_request_target

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,10 +4,14 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened ]
+    # Do NOT check out, build, or run untrusted code from the pull request with this event.
 
-permissions: write-all
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   pr-labeler:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When PR from public fork, Can not access configuration file in `pull_request` trigger.
e.g., https://github.com/DeNA/Anjin/actions/runs/4633726453

`pull_request_target` trigger is:

- GITHUB_TOKEN is granted read/write repository permission unless the permissions key is specified and the workflow can access secrets, even when it is triggered from a fork
- Runs in the context of the base of the pull request (NOT merge commit)

Refs:

- https://github.com/TimonVS/pr-labeler-action/issues/25#issuecomment-891051406
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

<!-- write content here -->

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).