### PR TITLE
Fix InitializeOnLaunchAutopilotAttribute acquisition process

### DIFF
--- a/Runtime/Launcher.cs
+++ b/Runtime/Launcher.cs
@@ -56,10 +56,7 @@ namespace DeNA.Anjin
 
         private static void CallAttachedInitializeOnLaunchAutopilotAttributeMethods()
         {
-            foreach (var methodInfo in AppDomain.CurrentDomain.GetAssemblies()
-                         .SelectMany(x => x.GetTypes())
-                         .SelectMany(x => x.GetMethods())
-                         .Where(x => x.GetCustomAttributes(typeof(InitializeOnLaunchAutopilotAttribute), false).Any()))
+            foreach (var methodInfo in TypeCache.GetMethodsWithAttribute<InitializeOnLaunchAutopilotAttribute>())
             {
                 methodInfo.Invoke(null, null); // static method only
             }


### PR DESCRIPTION
<!-- write content here -->

### Changes
`InitializeOnLaunchAutopilotAttribute` acquisition process was rewritten using [TypeCache.GetMethodsWithAttribute<T>()](https://docs.unity3d.com/ScriptReference/TypeCache.GetFieldsWithAttribute.html).

### Reason

- Performance Improvement
  - https://forum.unity.com/threads/unityeditor-typecache-api-for-fast-extraction-of-type-attributes-in-the-editor-tooling.687682/
---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).