### PR TITLE
forgot to call Apply on the texture copy of the screenshot

### DIFF
--- a/Runtime/Reporters/SlackReporter.cs
+++ b/Runtime/Reporters/SlackReporter.cs
@@ -69,6 +69,7 @@ namespace DeNA.Anjin.Reporters
                     var screenshot = ScreenCapture.CaptureScreenshotAsTexture();
                     var withoutAlpha = new Texture2D(screenshot.width, screenshot.height, TextureFormat.RGB24, false);
                     withoutAlpha.SetPixels(screenshot.GetPixels());
+                    withoutAlpha.Apply();
 
                     var postScreenshotTask = await _slackAPI.Post(_settings.slackToken, channel,
                         withoutAlpha.EncodeToPNG(), postTitleTask.Ts);


### PR DESCRIPTION
# Changes
SlackReporter screenshot process now performs Apply after copying the texture content.

# Reason
I am using SetPixels() to remove the alpha channel from a texture in a screenshot.
I have to execute Apply() after using this method, but I forgot to do it.
 -> https://docs.unity3d.com/ja/2019.4/ScriptReference/Texture2D.Apply.html

However, it works fine even if Apply() is not executed, so this is an insurance measure as well.
This is in anticipation of problems that may occur in some environments.


### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).