### PR TITLE
Fix for older Unity

### DIFF
--- a/Runtime/Reporters/SlackReporter.cs
+++ b/Runtime/Reporters/SlackReporter.cs
@@ -49,7 +49,7 @@ namespace DeNA.Anjin.Reporters
             // NOTE: In _sender.send, switch the execution thread to the main thread, so UniTask.WhenAll is meaningless.
             foreach (var slackChannel in (string.IsNullOrEmpty(settings.slackChannels)
                          ? slackChannels
-                         : settings.slackChannels).Split(","))
+                         : settings.slackChannels).Split(','))
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
@@ -59,7 +59,7 @@ namespace DeNA.Anjin.Reporters
                 await _sender.Send(
                     string.IsNullOrEmpty(settings.slackToken) ? slackToken : settings.slackToken,
                     slackChannel,
-                    mentionSubTeamIDs.Split(","),
+                    mentionSubTeamIDs.Split(','),
                     addHereInSlackMessage,
                     logString,
                     stackTrace,

--- a/Tests/Runtime/TestDoubles/StubClickAgent.cs
+++ b/Tests/Runtime/TestDoubles/StubClickAgent.cs
@@ -6,6 +6,7 @@ using Cysharp.Threading.Tasks;
 using DeNA.Anjin.Agents;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.SceneManagement;
 
 namespace DeNA.Anjin.TestDoubles
 {
@@ -23,7 +24,7 @@ namespace DeNA.Anjin.TestDoubles
         /// <inheritdoc />
         public override UniTask Run(CancellationToken token)
         {
-            foreach (var obj in FindObjectsByType<GameObject>(FindObjectsSortMode.None))
+            foreach (var obj in SceneManager.GetActiveScene().GetRootGameObjects())
             {
                 if (obj.name != targetName)
                 {


### PR DESCRIPTION
<!-- write content here -->

- `String.Split(string)` overload is added .NET Standard 2.1
- `GameObject.FindObjectsByType<t>` is added Unity 2020.3.4, 2021.3.18, 2022.2.5 or later.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).