### PR TITLE
Support launch autopilot from Play Mode tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -145,7 +145,7 @@ dotnet_naming_symbols.all_members.applicable_kinds = *
 
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
-file_header_template = Copyright (c) ${CurrentDate.Year} DeNA Co., Ltd.\nThis software is released under the MIT License.
+file_header_template = Copyright (c) 2023-${CurrentDate.Year} DeNA Co., Ltd.\nThis software is released under the MIT License.
 
 # RS0016: Only enable if API files are present
 dotnet_public_api_analyzer.require_api_files = true

--- a/Editor/Commandline.cs
+++ b/Editor/Commandline.cs
@@ -61,7 +61,7 @@ namespace DeNA.Anjin.Editor
 
             // Activate autopilot and enter play mode
             var state = AutopilotState.Instance;
-            state.launchFrom = AutopilotState.LaunchType.Commandline;
+            state.launchFrom = LaunchType.Commandline;
             state.settings = settings;
             EditorApplication.isPlaying = true;
 

--- a/Editor/UI/Settings/AutopilotSettingsEditor.cs
+++ b/Editor/UI/Settings/AutopilotSettingsEditor.cs
@@ -170,7 +170,7 @@ namespace DeNA.Anjin.Editor.UI.Settings
         internal async UniTask Stop()
         {
             var autopilot = FindObjectOfType<Autopilot>();
-            await autopilot.TerminateAsync(Autopilot.ExitCode.Normally);
+            await autopilot.TerminateAsync(ExitCode.Normally);
         }
 
         internal void Launch(AutopilotState state)
@@ -178,12 +178,12 @@ namespace DeNA.Anjin.Editor.UI.Settings
             state.settings = _settings;
             if (EditorApplication.isPlaying)
             {
-                state.launchFrom = AutopilotState.LaunchType.EditorPlayMode;
+                state.launchFrom = LaunchType.EditorPlayMode;
                 Launcher.Run();
             }
             else
             {
-                state.launchFrom = AutopilotState.LaunchType.EditorEditMode;
+                state.launchFrom = LaunchType.EditorEditMode;
                 EditorApplication.isPlaying = true;
             }
         }

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ You can choose from two typical installation methods.
 ![](Documentation~/PackageManager_Dark.png/#gh-dark-mode-only)
 ![](Documentation~/PackageManager_Light.png/#gh-light-mode-only)
 
-> **Note**  
+> [!NOTE]  
 > Do not forget to add `com.cysharp` and `com.nowsprinting` into scopes. These are used within Anjin.
 
-> **Note**  
+> [!NOTE]  
 > Required install [Unity Test Framework](https://docs.unity3d.com/Packages/com.unity.test-framework@latest) package v1.3 or later for running tests (when adding to the `testables` in package.json).
 
 ### Install via OpenUPM-CLI
@@ -77,7 +77,7 @@ After installing the UPM package in the game title project, configure and implem
 - Implement a custom Agent if necessary
 - Implement initialization process as needed
 
-> **Note**  
+> [!NOTE]  
 > Set `UNITY_EDITOR || DENA_AUTOPILOT_ENABLE` in the Define Constraints of the Assembly Definition File to which they belong to exclude them from release builds.
 
 
@@ -251,7 +251,7 @@ See **Anjin Annotations** below for more information.
 
 This is an Agent that playback uGUI operations with the Recorded Playback feature of the [Automated QA](https://docs.unity3d.com/Packages/com.unity.automated-testing@latest) package.
 
-> **Note**  
+> [!NOTE]  
 > The Automated QA package is in the preview stage. Please note that destructive changes may occur, and the package itself may be discontinued or withdrawn.
 
 The following can be set in an instance (.asset file) of this Agent.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,27 @@ Open the AutopilotSettings file you wish to run in the inspector and click the *
 After the set run time has elapsed, or as in normal play mode, clicking the Play button will stop the program.
 
 
-### 2. Run from commandline
+### 2. Run from Play Mode test
+
+Autopilot works within your test code using the async method `LauncherFromTest.AutopilotAsync(string)`.
+Specify the `AutopilotSettings` file path as the argument.
+
+```
+[Test]
+public async Task LaunchAutopilotFromTest()
+{
+  await LauncherFromTest.AutopilotAsync("Assets/Path/To/AutopilotSettings.asset");
+}
+```
+
+> [!NOTE]  
+> If an error is detected in running, it will be output to `LogError` and the test will fail.
+
+> [!WARNING]  
+> The default timeout for tests is 3 minutes. If the autopilot execution time exceeds 3 minutes, please specify the timeout time with the `Timeout` attribute.
+
+
+### 3. Run from commandline
 
 To execute from the commandline, specify the following arguments.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -168,7 +168,27 @@ Slack通知に付与するメンションを設定します。
 設定された実行時間が経過するか、通常の再生モードと同じく再生ボタンクリックで停止します。
 
 
-### 2. コマンドラインから実行
+### 2. Play Modeテストから実行
+
+非同期メソッド `LauncherFromTest.AutopilotAsync(string)` を使用することで、テストコード内でオートパイロットが動作します。
+引数には `AutopilotSettings` ファイルパスを指定します。
+
+```
+[Test]
+public async Task LaunchAutopilotFromTest()
+{
+  await LauncherFromTest.AutopilotAsync("Assets/Path/To/AutopilotSettings.asset");
+}
+```
+
+> [!NOTE]  
+> 実行中にエラーを検知すると `LogError` が出力されるため、そのテストは失敗と判定されます。
+
+> [!WARNING]  
+> テストのデフォルトタイムアウトは3分です。オートパイロットの実行時間が3分を超える場合は `Timeout` 属性でタイムアウト時間を指定してください。
+
+
+### 3. コマンドラインから実行
 
 コマンドラインから実行する場合、以下の引数を指定します。
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -40,10 +40,10 @@ Click [English](./README.md) for English page if you need.
 ![](Documentation~/PackageManager_Dark.png/#gh-dark-mode-only)
 ![](Documentation~/PackageManager_Light.png/#gh-light-mode-only)
 
-> **Note**  
+> [!NOTE]  
 > scopesに `com.cysharp` と `com.nowsprinting` を忘れず追加してください。Anjin内で使用しています。
 
-> **Note**  
+> [!NOTE]  
 > Anjinパッケージ内のテストを実行する場合（package.jsonの `testables` に追加するとき）は、[Unity Test Framework](https://docs.unity3d.com/Packages/com.unity.test-framework@latest) パッケージ v1.3以上が必要です。
 
 ### openupm-cli を使用する場合
@@ -76,7 +76,7 @@ Anjinを起動すると、次のファイルが自動生成されます。
 - 必要に応じて専用Agentの実装
 - 必要に応じて初期化処理の実装
 
-> **Note**  
+> [!NOTE]  
 > ゲームタイトル固有のオートパイロット向けコードは、属するAssembly Definition FileのDefine Constraintsに `UNITY_EDITOR || DENA_AUTOPILOT_ENABLE` を設定することで、リリースビルドから除外できます
 
 
@@ -252,7 +252,7 @@ uGUIのコンポーネントをランダムに操作するAgentです。
 
 [Automated QA](https://docs.unity3d.com/Packages/com.unity.automated-testing@latest)パッケージのRecorded Playback機能でレコーディングしたuGUI操作を再生するAgentです。
 
-> **Note**  
+> [!NOTE]  
 > Automated QAパッケージはプレビュー段階のため、破壊的変更や、パッケージ自体の開発中止・廃止もありえる点、ご注意ください。
 
 このAgentのインスタンス（.assetファイル）には以下を設定できます。

--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -93,7 +93,8 @@ namespace DeNA.Anjin
         /// <param name="logString">Log message string when terminate by the log message</param>
         /// <param name="stackTrace">Stack trace when terminate by the log message</param>
         /// <returns>A task awaits termination get completed</returns>
-        public async UniTask TerminateAsync(ExitCode exitCode, string logString = null, string stackTrace = null, CancellationToken token = default)
+        public async UniTask TerminateAsync(ExitCode exitCode, string logString = null, string stackTrace = null,
+            CancellationToken token = default)
         {
             if (_dispatcher != null)
             {
@@ -113,10 +114,11 @@ namespace DeNA.Anjin
 
             Destroy(this.gameObject);
 
-            if (_state.launchFrom == LaunchType.EditorPlayMode)
+            if (_state.IsLaunchFromPlayMode)
             {
                 _logger.Log("Terminate autopilot");
-                _state.Reset();
+                _state.settings = null;
+                _state.exitCode = exitCode;
                 return; // Only terminate autopilot run if starting from play mode.
             }
 

--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -117,8 +117,13 @@ namespace DeNA.Anjin
             if (_state.IsLaunchFromPlayMode)
             {
                 _logger.Log("Terminate autopilot");
-                _state.settings = null;
-                _state.exitCode = exitCode;
+                _state.Reset();
+#if UNITY_INCLUDE_TESTS
+                if (_state.launchFrom == LaunchType.PlayModeTests && exitCode != ExitCode.Normally)
+                {
+                    throw new NUnit.Framework.AssertionException($"Autopilot failed with exit code {exitCode}");
+                }
+#endif
                 return; // Only terminate autopilot run if starting from play mode.
             }
 

--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -19,27 +19,6 @@ namespace DeNA.Anjin
     /// </summary>
     public class Autopilot : MonoBehaviour
     {
-        /// <summary>
-        /// Exit code for autopilot running
-        /// </summary>
-        public enum ExitCode
-        {
-            /// <summary>
-            /// Normally exit
-            /// </summary>
-            Normally = 0,
-
-            /// <summary>
-            /// Exit by un catch Exceptions
-            /// </summary>
-            UnCatchExceptions = 1,
-
-            /// <summary>
-            /// Exit by fault in log message
-            /// </summary>
-            AutopilotFailed = 2
-        }
-
         private ILogger _logger;
         private RandomFactory _randomFactory;
         private IAgentDispatcher _dispatcher;
@@ -134,7 +113,7 @@ namespace DeNA.Anjin
 
             Destroy(this.gameObject);
 
-            if (_state.launchFrom == AutopilotState.LaunchType.EditorPlayMode)
+            if (_state.launchFrom == LaunchType.EditorPlayMode)
             {
                 _logger.Log("Terminate autopilot");
                 _state.Reset();

--- a/Runtime/ExitCode.cs
+++ b/Runtime/ExitCode.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2023-2024 DeNA Co., Ltd.
+// This software is released under the MIT License.
+
+namespace DeNA.Anjin
+{
+    /// <summary>
+    /// Exit code for autopilot running
+    /// </summary>
+    public enum ExitCode
+    {
+        /// <summary>
+        /// Normally exit
+        /// </summary>
+        Normally = 0,
+
+        /// <summary>
+        /// Exit by un catch Exceptions
+        /// </summary>
+        UnCatchExceptions = 1,
+
+        /// <summary>
+        /// Exit by fault in log message
+        /// </summary>
+        AutopilotFailed = 2
+    }
+}

--- a/Runtime/ExitCode.cs.meta
+++ b/Runtime/ExitCode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5238adde16cc4df8bd68d61826fba98c
+timeCreated: 1710279505

--- a/Runtime/LaunchType.cs
+++ b/Runtime/LaunchType.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2023-2024 DeNA Co., Ltd.
+// This software is released under the MIT License.
+
+namespace DeNA.Anjin
+{
+    /// <summary>
+    /// Define of what autopilot was launched by
+    /// </summary>
+    public enum LaunchType
+    {
+        /// <summary>
+        /// Not launch yet
+        /// </summary>
+        NotSet = 0,
+
+        /// <summary>
+        /// Launch via Edit mode
+        /// </summary>
+        EditorEditMode,
+
+        /// <summary>
+        /// Launch via Play mode
+        /// </summary>
+        EditorPlayMode,
+
+        /// <summary>
+        /// Launch from commandline interface
+        /// When autopilot is finished, Unity editor is also exit.
+        /// </summary>
+        Commandline,
+
+        /// <summary>
+        /// Launch on standalone platform player build (not support yet)
+        /// </summary>
+        Runtime,
+    }
+}

--- a/Runtime/LaunchType.cs
+++ b/Runtime/LaunchType.cs
@@ -24,6 +24,11 @@ namespace DeNA.Anjin
         EditorPlayMode,
 
         /// <summary>
+        /// Launch via Play mode tests
+        /// </summary>
+        PlayModeTests,
+
+        /// <summary>
         /// Launch from commandline interface
         /// When autopilot is finished, Unity editor is also exit.
         /// </summary>

--- a/Runtime/LaunchType.cs.meta
+++ b/Runtime/LaunchType.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3e29989dd48141fdba0ba0f253fd90a8
+timeCreated: 1710279555

--- a/Runtime/Launcher.cs
+++ b/Runtime/Launcher.cs
@@ -41,7 +41,7 @@ namespace DeNA.Anjin
                 return; // Normally play mode (not run autopilot)
             }
 
-            if (state.launchFrom != LaunchType.EditorPlayMode)
+            if (!state.IsLaunchFromPlayMode)
             {
                 EditorApplication.playModeStateChanged += OnChangePlayModeState;
             }

--- a/Runtime/Launcher.cs
+++ b/Runtime/Launcher.cs
@@ -41,7 +41,7 @@ namespace DeNA.Anjin
                 return; // Normally play mode (not run autopilot)
             }
 
-            if (state.launchFrom != AutopilotState.LaunchType.EditorPlayMode)
+            if (state.launchFrom != LaunchType.EditorPlayMode)
             {
                 EditorApplication.playModeStateChanged += OnChangePlayModeState;
             }
@@ -83,12 +83,12 @@ namespace DeNA.Anjin
             var state = AutopilotState.Instance;
             switch (state.launchFrom)
             {
-                case AutopilotState.LaunchType.EditorEditMode:
+                case LaunchType.EditorEditMode:
                     Debug.Log("Exit play mode");
                     state.Reset();
                     break;
 
-                case AutopilotState.LaunchType.Commandline:
+                case LaunchType.Commandline:
                     // Exit Unity when returning from play mode to edit mode.
                     // Because it may freeze when exiting without going through edit mode.
                     var exitCode = (int)state.exitCode;

--- a/Runtime/LauncherFromTest.cs
+++ b/Runtime/LauncherFromTest.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2023-2024 DeNA Co., Ltd.
+// This software is released under the MIT License.
+
+using Cysharp.Threading.Tasks;
+using DeNA.Anjin.Settings;
+using NUnit.Framework;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace DeNA.Anjin
+{
+    /// <summary>
+    /// Launch from Play Mode test interface.
+    /// </summary>
+    public static class LauncherFromTest
+    {
+        /// <summary>
+        /// Run autopilot from Play Mode test.
+        /// If an error is detected in running, it will be output to `LogError` and the test will fail.
+        /// </summary>
+        /// <param name="settings">Autopilot settings</param>
+        public static async UniTask AutopilotAsync(AutopilotSettings settings)
+        {
+#if UNITY_EDITOR
+            if (!EditorApplication.isPlaying)
+            {
+                throw new AssertionException("Not support run on Edit Mode tests");
+            }
+#endif
+            var state = AutopilotState.Instance;
+            if (state.IsRunning)
+            {
+                throw new AssertionException("Autopilot is already running");
+            }
+
+            state.Reset();
+            state.launchFrom = LaunchType.PlayModeTests;
+            state.settings = settings;
+            Launcher.Run();
+
+            await UniTask.WaitUntil(() => !state.IsRunning);
+
+            if (state.exitCode != ExitCode.Normally)
+            {
+                throw new AssertionException($"Autopilot failed with exit code {state.exitCode}");
+            }
+        }
+
+        /// <summary>
+        /// Run autopilot from Play Mode test.
+        /// If an error is detected in running, it will be output to `LogError` and the test will fail.
+        /// </summary>
+        /// <param name="autopilotSettingsPath">Asset file path for autopilot settings</param>
+        public static async UniTask AutopilotAsync(string autopilotSettingsPath)
+        {
+            var settings = AssetDatabase.LoadAssetAtPath<AutopilotSettings>(autopilotSettingsPath);
+            await AutopilotAsync(settings);
+        }
+    }
+}

--- a/Runtime/LauncherFromTest.cs
+++ b/Runtime/LauncherFromTest.cs
@@ -34,17 +34,11 @@ namespace DeNA.Anjin
                 throw new AssertionException("Autopilot is already running");
             }
 
-            state.Reset();
             state.launchFrom = LaunchType.PlayModeTests;
             state.settings = settings;
             Launcher.Run();
 
             await UniTask.WaitUntil(() => !state.IsRunning);
-
-            if (state.exitCode != ExitCode.Normally)
-            {
-                throw new AssertionException($"Autopilot failed with exit code {state.exitCode}");
-            }
         }
 
         /// <summary>

--- a/Runtime/LauncherFromTest.cs.meta
+++ b/Runtime/LauncherFromTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 67daa96e39994bae9c5a2e9382d2d1f5
+timeCreated: 1710574470

--- a/Runtime/Settings/AutopilotState.cs
+++ b/Runtime/Settings/AutopilotState.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 DeNA Co., Ltd.
+﻿// Copyright (c) 2023-2024 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
 using System;
@@ -53,6 +53,17 @@ namespace DeNA.Anjin.Settings
             get
             {
                 return this.settings;
+            }
+        }
+
+        /// <summary>
+        /// Is launch from play mode (Editor play mode or Play Mode tests)
+        /// </summary>
+        public bool IsLaunchFromPlayMode
+        {
+            get
+            {
+                return launchFrom == LaunchType.EditorPlayMode || launchFrom == LaunchType.PlayModeTests;
             }
         }
 

--- a/Runtime/Settings/AutopilotState.cs
+++ b/Runtime/Settings/AutopilotState.cs
@@ -17,38 +17,6 @@ namespace DeNA.Anjin.Settings
     public class AutopilotState : ScriptableObject
     {
         /// <summary>
-        /// Define of what autopilot was launched by
-        /// </summary>
-        public enum LaunchType
-        {
-            /// <summary>
-            /// Not launch yet
-            /// </summary>
-            NotSet = 0,
-
-            /// <summary>
-            /// Launch via Edit mode
-            /// </summary>
-            EditorEditMode,
-
-            /// <summary>
-            /// Launch via Play mode
-            /// </summary>
-            EditorPlayMode,
-
-            /// <summary>
-            /// Launch from commandline interface
-            /// When autopilot is finished, Unity editor is also exit.
-            /// </summary>
-            Commandline,
-
-            /// <summary>
-            /// Launch on standalone platform player build (not support yet)
-            /// </summary>
-            Runtime,
-        }
-
-        /// <summary>
         /// Launch type
         /// </summary>
         [HideInInspector] public LaunchType launchFrom = LaunchType.NotSet;
@@ -61,7 +29,7 @@ namespace DeNA.Anjin.Settings
         /// <summary>
         /// Exit code when terminate autopilot from commandline interface
         /// </summary>
-        [HideInInspector] public Autopilot.ExitCode exitCode;
+        [HideInInspector] public ExitCode exitCode;
 
         /// <summary>
         /// Reset run state
@@ -70,7 +38,7 @@ namespace DeNA.Anjin.Settings
         {
             launchFrom = LaunchType.NotSet;
             settings = null;
-            exitCode = Autopilot.ExitCode.Normally;
+            exitCode = ExitCode.Normally;
         }
 
         /// <summary>

--- a/Runtime/Utilities/LogMessageHandler.cs
+++ b/Runtime/Utilities/LogMessageHandler.cs
@@ -51,7 +51,7 @@ namespace DeNA.Anjin.Utilities
             var autopilot = Object.FindObjectOfType<Autopilot>();
             if (autopilot != null)
             {
-                await autopilot.TerminateAsync(Autopilot.ExitCode.AutopilotFailed, logString, stackTrace);
+                await autopilot.TerminateAsync(ExitCode.AutopilotFailed, logString, stackTrace);
             }
         }
 

--- a/Tests/Runtime/LauncherFromTestTest.cs
+++ b/Tests/Runtime/LauncherFromTestTest.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2023-2024 DeNA Co., Ltd.
+// This software is released under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DeNA.Anjin.Agents;
+using DeNA.Anjin.Settings;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace DeNA.Anjin
+{
+    [TestFixture]
+    public class LauncherFromTestTest
+    {
+        [Test]
+        public async Task AutopilotAsync_RunAutopilot()
+        {
+            var agent = ScriptableObject.CreateInstance(typeof(DoNothingAgent)) as DoNothingAgent;
+            agent.lifespanSec = 1;
+
+            var settings = ScriptableObject.CreateInstance(typeof(AutopilotSettings)) as AutopilotSettings;
+            settings.sceneAgentMaps = new List<SceneAgentMap>();
+            settings.fallbackAgent = agent;
+            settings.lifespanSec = 2;
+
+            var beforeTimestamp = Time.time;
+            await LauncherFromTest.AutopilotAsync(settings);
+
+            var afterTimestamp = Time.time;
+            Assert.That(afterTimestamp - beforeTimestamp, Is.GreaterThan(2f), "Autopilot is running for 2 seconds");
+
+            var state = AutopilotState.Instance;
+            Assert.That(state.IsRunning, Is.False, "AutopilotState is terminated");
+            Assert.That(state.launchFrom, Is.EqualTo(LaunchType.PlayModeTests), "Launch from");
+            Assert.That(state.exitCode, Is.EqualTo(ExitCode.Normally), "Exit code");
+            Assert.That(EditorApplication.isPlaying, Is.True, "Keep play mode");
+        }
+
+        [Test]
+        public async Task AutopilotAsync_WithAssetFile_RunAutopilot()
+        {
+            const string AssetPath = "Packages/com.dena.anjin/Tests/TestAssets/AutopilotSettingsForTests.asset";
+
+            var beforeTimestamp = Time.time;
+            await LauncherFromTest.AutopilotAsync(AssetPath);
+
+            var afterTimestamp = Time.time;
+            Assert.That(afterTimestamp - beforeTimestamp, Is.GreaterThan(2f), "Autopilot is running for 2 seconds");
+
+            var state = AutopilotState.Instance;
+            Assert.That(state.IsRunning, Is.False, "AutopilotState is terminated");
+            Assert.That(state.launchFrom, Is.EqualTo(LaunchType.PlayModeTests), "Launch from");
+            Assert.That(state.exitCode, Is.EqualTo(ExitCode.Normally), "Exit code");
+            Assert.That(EditorApplication.isPlaying, Is.True, "Keep play mode");
+        }
+    }
+}

--- a/Tests/Runtime/LauncherFromTestTest.cs
+++ b/Tests/Runtime/LauncherFromTestTest.cs
@@ -33,8 +33,8 @@ namespace DeNA.Anjin
 
             var state = AutopilotState.Instance;
             Assert.That(state.IsRunning, Is.False, "AutopilotState is terminated");
-            Assert.That(state.launchFrom, Is.EqualTo(LaunchType.PlayModeTests), "Launch from");
-            Assert.That(state.exitCode, Is.EqualTo(ExitCode.Normally), "Exit code");
+            Assert.That(state.launchFrom, Is.EqualTo(LaunchType.NotSet), "Launch from is reset");
+            Assert.That(state.exitCode, Is.EqualTo(ExitCode.Normally), "Exit code is reset");
             Assert.That(EditorApplication.isPlaying, Is.True, "Keep play mode");
         }
 
@@ -51,8 +51,8 @@ namespace DeNA.Anjin
 
             var state = AutopilotState.Instance;
             Assert.That(state.IsRunning, Is.False, "AutopilotState is terminated");
-            Assert.That(state.launchFrom, Is.EqualTo(LaunchType.PlayModeTests), "Launch from");
-            Assert.That(state.exitCode, Is.EqualTo(ExitCode.Normally), "Exit code");
+            Assert.That(state.launchFrom, Is.EqualTo(LaunchType.NotSet), "Launch from is reset");
+            Assert.That(state.exitCode, Is.EqualTo(ExitCode.Normally), "Exit code is reset");
             Assert.That(EditorApplication.isPlaying, Is.True, "Keep play mode");
         }
     }

--- a/Tests/Runtime/LauncherFromTestTest.cs.meta
+++ b/Tests/Runtime/LauncherFromTestTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 54bc6c4002634baa983e79cb35ea447f
+timeCreated: 1710578007

--- a/Tests/Runtime/LauncherTest.cs
+++ b/Tests/Runtime/LauncherTest.cs
@@ -33,13 +33,13 @@ namespace DeNA.Anjin
 
             await Task.Delay(200);
 
-            Assert.That(state.launchFrom, Is.EqualTo(AutopilotState.LaunchType.EditorPlayMode));
+            Assert.That(state.launchFrom, Is.EqualTo(LaunchType.EditorPlayMode));
             Assert.That(state.IsRunning, Is.True, "AutopilotState is running");
 
             var autopilot = Object.FindObjectOfType<Autopilot>();
             Assert.That((bool)autopilot, Is.True, "Autopilot object is alive");
 
-            await autopilot.TerminateAsync(Autopilot.ExitCode.Normally);
+            await autopilot.TerminateAsync(ExitCode.Normally);
         }
 
         [Test]


### PR DESCRIPTION
### Changes

- Add launcher from test
- Refactor enum


### Usage

Autopilot works within your test code using the async method `LauncherFromTest.AutopilotAsync(string)`.
Specify the `AutopilotSettings` file path as the argument.

```
[Test]
public async Task LaunchAutopilotFromTest()
{
  await LauncherFromTest.AutopilotAsync("Assets/Path/To/AutopilotSettings.asset");
}
```

> [!NOTE]  
> If an error is detected in running, it will be output to `LogError` and the test will fail.

> [!WARNING]  
> The default timeout for tests is 3 minutes. If the autopilot execution time exceeds 3 minutes, please specify the timeout time with the `Timeout` attribute.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).