### PR TITLE
Fix default screenshots filename prefix to agent name

### DIFF
--- a/Runtime/Agents/UGUIMonkeyAgent.cs
+++ b/Runtime/Agents/UGUIMonkeyAgent.cs
@@ -112,7 +112,7 @@ namespace DeNA.Anjin.Agents
                     {
                         Directory = defaultScreenshotDirectory ? null : screenshotDirectory,
                         FilenameStrategy = new CounterBasedStrategy(
-                            defaultScreenshotFilenamePrefix ? null : screenshotFilenamePrefix
+                            defaultScreenshotFilenamePrefix ? this.name : screenshotFilenamePrefix
                         ),
                         SuperSize = screenshotSuperSize,
                         StereoCaptureMode = screenshotStereoCaptureMode

--- a/Tests/Runtime/Agents/UGUIMonkeyAgentTest.cs
+++ b/Tests/Runtime/Agents/UGUIMonkeyAgentTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 DeNA Co., Ltd.
+﻿// Copyright (c) 2023-2024 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
 using System;
@@ -12,7 +12,6 @@ using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
-using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
 namespace DeNA.Anjin.Agents
@@ -70,20 +69,6 @@ namespace DeNA.Anjin.Agents
 
                 Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Succeeded));
             }
-        }
-
-        [Test]
-        public void Check_SelectableProperties()
-        {
-            var button = new GameObject("button1", new[] { typeof(RectTransform), typeof(Button) });
-            var canvas = new GameObject().AddComponent<Canvas>();
-            button.transform.parent = canvas.transform;
-
-            // Verify properties needed to process with `UIDetector.Item.From()`.
-            var selectable = button.GetComponent<Selectable>();
-            Assert.That(selectable.interactable, Is.True);
-            Assert.That(selectable.transform.GetType(), Is.EqualTo(typeof(RectTransform)));
-            Assert.That(selectable.GetComponentInParent<Canvas>(), Is.Not.Null);
         }
     }
 }

--- a/Tests/Runtime/DeNA.Anjin.Tests.asmdef
+++ b/Tests/Runtime/DeNA.Anjin.Tests.asmdef
@@ -8,7 +8,8 @@
         "DeNA.Anjin.Annotations",
         "UniTask",
         "DeNA.Anjin.Editor",
-        "TestHelper"
+        "TestHelper",
+        "TestHelper.RuntimeInternals"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
### Problem
Screenshots filename prefix is Always "Run_" when `defaultScreenshotFilenamePrefix` is true.

### Fix
Use agent name instead of `[CallerMemberName]`.
(That's what the README says!)

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).