### PR TITLE
Fix duplicate agent creation when reactivating scene

### DIFF
--- a/Runtime/AgentDispatcher.cs
+++ b/Runtime/AgentDispatcher.cs
@@ -85,17 +85,21 @@ namespace DeNA.Anjin
 
             if (!agent)
             {
-                if (!_settings.fallbackAgent)
+                if (_settings.fallbackAgent)
+                {
+                    _logger.Log($"Use fallback agent. scene: {scene.path}");
+                    agent = _settings.fallbackAgent;
+                }
+                else
                 {
                     _logger.Log(LogType.Warning, $"Agent not found by scene: {scene.name}");
-                    return;
                 }
-
-                _logger.Log($"Use fallback agent. scene: {scene.path}");
-                agent = _settings.fallbackAgent;
             }
 
-            DispatchAgent(agent);
+            if (agent)
+            {
+                DispatchAgent(agent);
+            }
 
             if (_settings.observerAgent != null)
             {

--- a/Runtime/AgentDispatcher.cs
+++ b/Runtime/AgentDispatcher.cs
@@ -19,9 +19,9 @@ namespace DeNA.Anjin
         /// <summary>
         /// Agent dispatch by next scene
         /// </summary>
-        /// <param name="current">Current scene</param>
-        /// <param name="next">Next transition scene</param>
-        void DispatchByScene(Scene current, Scene next);
+        /// <param name="next"></param>
+        /// <param name="mode"></param>
+        void DispatchByScene(Scene next, LoadSceneMode mode);
 
         /// <summary>
         /// Agent dispatch by current scene
@@ -48,28 +48,21 @@ namespace DeNA.Anjin
             _settings = settings;
             _logger = logger;
             _randomFactory = randomFactory;
-            SceneManager.activeSceneChanged += this.DispatchByScene;
+            SceneManager.sceneLoaded += this.DispatchByScene;
         }
 
         public void Dispose()
         {
-            SceneManager.activeSceneChanged -= this.DispatchByScene;
+            SceneManager.sceneLoaded -= this.DispatchByScene;
         }
 
-        /// <summary>
-        /// Dispatch agent mapped to Scene `next`
-        /// </summary>
-        /// <param name="current"></param>
-        /// <param name="next"></param>
-        public void DispatchByScene(Scene current, Scene next)
+        /// <inheritdoc/>
+        public void DispatchByScene(Scene next, LoadSceneMode mode)
         {
             DispatchByScene(next);
         }
 
-        /// <summary>
-        /// Dispatch agent mapped to Scene
-        /// </summary>
-        /// <param name="scene"></param>
+        /// <inheritdoc/>
         public void DispatchByScene(Scene scene)
         {
             AbstractAgent agent = null;

--- a/Runtime/AgentDispatcher.cs
+++ b/Runtime/AgentDispatcher.cs
@@ -14,7 +14,7 @@ namespace DeNA.Anjin
     /// <summary>
     /// Agent dispatcher interface
     /// </summary>
-    public interface IAgentDispatcher
+    public interface IAgentDispatcher : IDisposable
     {
         /// <summary>
         /// Agent dispatch by next scene
@@ -30,7 +30,7 @@ namespace DeNA.Anjin
         void DispatchByScene(Scene scene);
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public class AgentDispatcher : IAgentDispatcher
     {
         private readonly AutopilotSettings _settings;
@@ -48,6 +48,12 @@ namespace DeNA.Anjin
             _settings = settings;
             _logger = logger;
             _randomFactory = randomFactory;
+            SceneManager.activeSceneChanged += this.DispatchByScene;
+        }
+
+        public void Dispose()
+        {
+            SceneManager.activeSceneChanged -= this.DispatchByScene;
         }
 
         /// <summary>
@@ -107,7 +113,7 @@ namespace DeNA.Anjin
 
             agent.Logger = _logger;
             agent.Random = _randomFactory.CreateRandom();
-            
+
             try
             {
                 agent.Run(token).Forget();

--- a/Runtime/AgentDispatcher.cs
+++ b/Runtime/AgentDispatcher.cs
@@ -17,13 +17,6 @@ namespace DeNA.Anjin
     public interface IAgentDispatcher : IDisposable
     {
         /// <summary>
-        /// Agent dispatch by next scene
-        /// </summary>
-        /// <param name="next"></param>
-        /// <param name="mode"></param>
-        void DispatchByScene(Scene next, LoadSceneMode mode);
-
-        /// <summary>
         /// Agent dispatch by current scene
         /// </summary>
         /// <param name="scene">Current scene</param>
@@ -56,8 +49,7 @@ namespace DeNA.Anjin
             SceneManager.sceneLoaded -= this.DispatchByScene;
         }
 
-        /// <inheritdoc/>
-        public void DispatchByScene(Scene next, LoadSceneMode mode)
+        private void DispatchByScene(Scene next, LoadSceneMode mode)
         {
             DispatchByScene(next);
         }

--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Threading;
 using Cysharp.Threading.Tasks;
-using DeNA.Anjin.Reporters;
 using DeNA.Anjin.Settings;
 using DeNA.Anjin.Utilities;
 using UnityEngine;
@@ -51,7 +50,6 @@ namespace DeNA.Anjin
 
             _dispatcher = new AgentDispatcher(_settings, _logger, _randomFactory);
             _dispatcher.DispatchByScene(SceneManager.GetActiveScene());
-            SceneManager.activeSceneChanged += _dispatcher.DispatchByScene;
 
             if (_settings.lifespanSec > 0)
             {
@@ -92,13 +90,14 @@ namespace DeNA.Anjin
         /// <param name="exitCode">Exit code for Unity Editor</param>
         /// <param name="logString">Log message string when terminate by the log message</param>
         /// <param name="stackTrace">Stack trace when terminate by the log message</param>
+        /// <param name="token">Cancellation token</param>
         /// <returns>A task awaits termination get completed</returns>
         public async UniTask TerminateAsync(ExitCode exitCode, string logString = null, string stackTrace = null,
             CancellationToken token = default)
         {
             if (_dispatcher != null)
             {
-                SceneManager.activeSceneChanged -= _dispatcher.DispatchByScene;
+                _dispatcher.Dispose();
             }
 
             if (_logMessageHandler != null)

--- a/Tests/Runtime/AgentDispatcherTest.cs
+++ b/Tests/Runtime/AgentDispatcherTest.cs
@@ -81,6 +81,12 @@ namespace DeNA.Anjin
             return scene;
         }
 
+        private static IEnumerable<string> FindAliveAgentNames()
+        {
+            return Object.FindObjectsOfType<AsyncDestroyTrigger>().Select(x => x.name);
+            // Note: AsyncDestroyTrigger is a component attached to the GameObject when binding agent by GetCancellationTokenOnDestroy.
+        }
+
         [Test]
         public async Task DispatchByScene_DispatchAgentBySceneAgentMaps()
         {
@@ -94,7 +100,7 @@ namespace DeNA.Anjin
 
             await LoadTestSceneAsync(TestScenePath);
 
-            var actual = Object.FindObjectsOfType<AsyncDestroyTrigger>().Select(x => x.name);
+            var actual = FindAliveAgentNames();
             Assert.That(actual, Is.EquivalentTo(new[] { AgentName }));
         }
 
@@ -108,7 +114,7 @@ namespace DeNA.Anjin
 
             await LoadTestSceneAsync(TestScenePath);
 
-            var actual = Object.FindObjectsOfType<AsyncDestroyTrigger>().Select(x => x.name);
+            var actual = FindAliveAgentNames();
             Assert.That(actual, Is.EquivalentTo(new[] { AgentName }));
         }
 
@@ -120,7 +126,7 @@ namespace DeNA.Anjin
 
             await LoadTestSceneAsync(TestScenePath);
 
-            var actual = Object.FindObjectsOfType<AsyncDestroyTrigger>().Select(x => x.name);
+            var actual = FindAliveAgentNames();
             Assert.That(actual, Is.Empty);
             LogAssert.Expect(LogType.Warning, "Agent not found by scene: Buttons");
         }
@@ -135,7 +141,7 @@ namespace DeNA.Anjin
 
             await LoadTestSceneAsync(TestScenePath);
 
-            var actual = Object.FindObjectsOfType<AsyncDestroyTrigger>().Select(x => x.name);
+            var actual = FindAliveAgentNames();
             Assert.That(actual, Is.EquivalentTo(new[] { AgentName }));
         }
 
@@ -152,7 +158,7 @@ namespace DeNA.Anjin
 
             var scene = await LoadTestSceneAsync(TestScenePath);
 
-            var agents = Object.FindObjectsOfType<AbstractAgent>().Select(x => x.name);
+            var agents = FindAliveAgentNames();
             Assume.That(agents, Is.EquivalentTo(new[] { AgentName }));
 
             var additiveScene = await LoadTestSceneAsync(TestScenePath2, LoadSceneMode.Additive);
@@ -160,7 +166,7 @@ namespace DeNA.Anjin
 
             SceneManager.SetActiveScene(scene); // Re-activate
 
-            var actual = Object.FindObjectsOfType<AsyncDestroyTrigger>().Select(x => x.name);
+            var actual = FindAliveAgentNames();
             Assert.That(actual, Is.EquivalentTo(new[] { AgentName }));
         }
     }

--- a/Tests/Runtime/AgentDispatcherTest.cs
+++ b/Tests/Runtime/AgentDispatcherTest.cs
@@ -3,10 +3,8 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
-using Cysharp.Threading.Tasks.Triggers;
 using DeNA.Anjin.Agents;
 using DeNA.Anjin.Settings;
 using DeNA.Anjin.TestDoubles;

--- a/Tests/Runtime/AgentDispatcherTest.cs
+++ b/Tests/Runtime/AgentDispatcherTest.cs
@@ -30,7 +30,7 @@ namespace DeNA.Anjin
         [TearDown]
         public void TearDown()
         {
-            SceneManager.activeSceneChanged -= _dispatcher.DispatchByScene;
+            _dispatcher?.Dispose();
         }
 
         private static AutopilotSettings CreateAutopilotSettings()
@@ -53,7 +53,6 @@ namespace DeNA.Anjin
             var randomFactory = new RandomFactory(0);
 
             _dispatcher = new AgentDispatcher(settings, logger, randomFactory);
-            SceneManager.activeSceneChanged += _dispatcher.DispatchByScene;
         }
 
         private const string TestScenePath = "Packages/com.dena.anjin/Tests/TestScenes/Buttons.unity";

--- a/Tests/Runtime/TestDoubles/SpyAliveCountAgent.cs
+++ b/Tests/Runtime/TestDoubles/SpyAliveCountAgent.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) 2023-2024 DeNA Co., Ltd.
+// This software is released under the MIT License.
+
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using DeNA.Anjin.Agents;
+using UnityEngine;
+
+namespace DeNA.Anjin.TestDoubles
+{
+    /// <summary>
+    /// Spy agent that count the number of alive instances.
+    /// </summary>
+    [AddComponentMenu("")]
+    // ReSharper disable once RequiredBaseTypesIsNotInherited
+    public class SpyAliveCountAgent : AbstractAgent
+    {
+        public static int AliveInstances { get; private set; }
+
+        public override async UniTask Run(CancellationToken token)
+        {
+            AliveInstances++;
+            try
+            {
+                await UniTask.WaitWhile(() => true, cancellationToken: token); // Wait indefinitely
+            }
+            finally
+            {
+                AliveInstances--;
+            }
+        }
+    }
+}

--- a/Tests/Runtime/TestDoubles/SpyAliveCountAgent.cs.meta
+++ b/Tests/Runtime/TestDoubles/SpyAliveCountAgent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a45a8161cc09438b9b33c7a670e39335
+timeCreated: 1713821110


### PR DESCRIPTION
Fixed two bugs.

## Fix duplicate agent creation when reactivating scene

### Problem
Duplicate agent creation.

### Conditions
1. Load and activate scene-A, creation agent-A
2. Load scene-B additive and activate (scene-A and agent-A remain)
3. Re-activate scene-A

### Cause
Agent creation when `SceneManager.activeSceneChanged`.

### Fix
Agent creation when `SceneManager.sceneLoaded`.


## Fix not dispatch observer agent case

### Problem
Not dispatch (creation) observer agent.

### Conditions
Specify observer agent, but not specify fallback agent.

### Cause
Return before creating observer agent when not specified fallback agent.

### Fix
Create observer agent even if fallback agent is not specified.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).