### PR TITLE
Fix agents do not output exit log if canceled

### DIFF
--- a/Runtime/Agents/DoNothingAgent.cs
+++ b/Runtime/Agents/DoNothingAgent.cs
@@ -24,16 +24,21 @@ namespace DeNA.Anjin.Agents
         {
             Logger.Log($"Enter {this.name}.Run()");
 
-            if (lifespanSec > 0)
+            try
             {
-                await UniTask.Delay(TimeSpan.FromSeconds(lifespanSec), cancellationToken: token);
+                if (lifespanSec > 0)
+                {
+                    await UniTask.Delay(TimeSpan.FromSeconds(lifespanSec), cancellationToken: token);
+                }
+                else
+                {
+                    await UniTask.WaitWhile(() => true, cancellationToken: token); // Wait indefinitely
+                }
             }
-            else
+            finally
             {
-                await UniTask.WaitWhile(() => true, cancellationToken: token); // 無期限に待機
+                Logger.Log($"Exit {this.name}.Run()");
             }
-
-            Logger.Log($"Exit {this.name}.Run()");
         }
     }
 }

--- a/Runtime/Agents/EmergencyExitAgent.cs
+++ b/Runtime/Agents/EmergencyExitAgent.cs
@@ -26,27 +26,32 @@ namespace DeNA.Anjin.Agents
             Logger.Log($"Enter {this.name}.Run()");
 
             var selectables = new Selectable[20];
-            while (true)
+            try
             {
-                var allSelectableCount = Selectable.allSelectableCount;
-                if (selectables.Length < allSelectableCount)
+                while (true) // Note: This agent is not terminate myself
                 {
-                    selectables = new Selectable[allSelectableCount];
-                }
-
-                Selectable.AllSelectablesNoAlloc(selectables);
-                for (var i = 0; i < allSelectableCount; i++)
-                {
-                    if (selectables[i].TryGetComponent<EmergencyExit>(out var emergencyExit))
+                    var allSelectableCount = Selectable.allSelectableCount;
+                    if (selectables.Length < allSelectableCount)
                     {
-                        ClickEmergencyExitButton(emergencyExit);
+                        selectables = new Selectable[allSelectableCount];
                     }
+
+                    Selectable.AllSelectablesNoAlloc(selectables);
+                    for (var i = 0; i < allSelectableCount; i++)
+                    {
+                        if (selectables[i].TryGetComponent<EmergencyExit>(out var emergencyExit))
+                        {
+                            ClickEmergencyExitButton(emergencyExit);
+                        }
+                    }
+
+                    await UniTask.NextFrame(token);
                 }
-
-                await UniTask.NextFrame(token);
             }
-
-            // Note: This agent is not terminate myself
+            finally
+            {
+                Logger.Log($"Exit {this.name}.Run()");
+            }
         }
 
         [SuppressMessage("ReSharper", "SuggestBaseTypeForParameter")]

--- a/Runtime/Agents/OneTimeAgent.cs
+++ b/Runtime/Agents/OneTimeAgent.cs
@@ -47,9 +47,14 @@ namespace DeNA.Anjin.Agents
 
             agent.Logger = Logger;
             agent.Random = Random; // This Agent does not consume pseudo-random numbers, so passed on as is.
-            await agent.Run(token);
-
-            Logger.Log($"Exit {this.name}.Run()");
+            try
+            {
+                await agent.Run(token);
+            }
+            finally
+            {
+                Logger.Log($"Exit {this.name}.Run()");
+            }
         }
     }
 }

--- a/Runtime/Agents/ParallelCompositeAgent.cs
+++ b/Runtime/Agents/ParallelCompositeAgent.cs
@@ -28,9 +28,14 @@ namespace DeNA.Anjin.Agents
                 tasks[i] = agent.Run(token);
             }
 
-            await UniTask.WhenAll(tasks);
-
-            Logger.Log($"Exit {this.name}.Run()");
+            try
+            {
+                await UniTask.WhenAll(tasks);
+            }
+            finally
+            {
+                Logger.Log($"Exit {this.name}.Run()");
+            }
         }
     }
 }

--- a/Runtime/Agents/RepeatAgent.cs
+++ b/Runtime/Agents/RepeatAgent.cs
@@ -26,14 +26,19 @@ namespace DeNA.Anjin.Agents
         {
             Logger.Log($"Enter {this.name}.Run()");
 
-            while (true)
+            agent.Logger = Logger;
+            agent.Random = Random; // This Agent does not consume pseudo-random numbers, so passed on as is.
+            try
             {
-                agent.Logger = Logger;
-                agent.Random = Random; // This Agent does not consume pseudo-random numbers, so passed on as is.
-                await agent.Run(token);
+                while (true) // Note: This agent is not terminate myself
+                {
+                    await agent.Run(token);
+                }
             }
-
-            // Note: This agent is not terminate myself
+            finally
+            {
+                Logger.Log($"Exit {this.name}.Run()");
+            }
         }
     }
 }

--- a/Runtime/Agents/SerialCompositeAgent.cs
+++ b/Runtime/Agents/SerialCompositeAgent.cs
@@ -18,14 +18,19 @@ namespace DeNA.Anjin.Agents
         {
             Logger.Log($"Enter {this.name}.Run()");
 
-            foreach (var agent in agents)
+            try
             {
-                agent.Logger = Logger;
-                agent.Random = RandomFactory.CreateRandom();
-                await agent.Run(token);
+                foreach (var agent in agents)
+                {
+                    agent.Logger = Logger;
+                    agent.Random = RandomFactory.CreateRandom();
+                    await agent.Run(token);
+                }
             }
-
-            Logger.Log($"Exit {this.name}.Run()");
+            finally
+            {
+                Logger.Log($"Exit {this.name}.Run()");
+            }
         }
     }
 }

--- a/Runtime/Agents/UGUIMonkeyAgent.cs
+++ b/Runtime/Agents/UGUIMonkeyAgent.cs
@@ -127,9 +127,15 @@ namespace DeNA.Anjin.Agents
                         randomString: new RandomStringImpl(random)),
                 },
             };
-            await Monkey.Run(config, token);
 
-            Logger.Log($"Exit {this.name}.Run()");
+            try
+            {
+                await Monkey.Run(config, token);
+            }
+            finally
+            {
+                Logger.Log($"Exit {this.name}.Run()");
+            }
         }
 
         private RandomStringParameters GetRandomStringParameters(GameObject gameObject)

--- a/Tests/Runtime/Agents/DoNothingAgentTest.cs
+++ b/Tests/Runtime/Agents/DoNothingAgentTest.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) 2023 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using DeNA.Anjin.Utilities;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 
 namespace DeNA.Anjin.Agents
@@ -23,17 +23,18 @@ namespace DeNA.Anjin.Agents
             agent.name = nameof(Run_cancelTask_stopAgent);
             agent.lifespanSec = 0; // Expect indefinite execution
 
-            var agentName = agent.GetType().Name;
-            var gameObject = new GameObject(agentName);
+            var gameObject = new GameObject();
             var token = gameObject.GetCancellationTokenOnDestroy();
             var task = agent.Run(token);
-            await UniTask.Delay(TimeSpan.FromSeconds(1), cancellationToken: token);
+            await UniTask.NextFrame();
 
             Object.DestroyImmediate(gameObject);
-            // ReSharper disable once MethodSupportsCancellation
             await UniTask.NextFrame();
 
             Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Canceled));
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
 
         [Test]
@@ -49,10 +50,13 @@ namespace DeNA.Anjin.Agents
             {
                 var token = cancellationTokenSource.Token;
                 var task = agent.Run(token);
-                await UniTask.Delay(TimeSpan.FromSeconds(2), cancellationToken: token); // Consider overhead
+                await UniTask.Delay(2000); // Consider overhead
 
                 Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Succeeded));
             }
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
     }
 }

--- a/Tests/Runtime/Agents/ParallelCompositeAgentTest.cs
+++ b/Tests/Runtime/Agents/ParallelCompositeAgentTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2023 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,9 +30,9 @@ namespace DeNA.Anjin.Agents
         [Test]
         public async Task Run_cancelTask_stopAgent()
         {
-            var firstChildAgent = CreateChildAgent(5000);
-            var secondChildAgent = CreateChildAgent(5000);
-            var lastChildAgent = CreateChildAgent(5000);
+            var firstChildAgent = CreateChildAgent(500);
+            var secondChildAgent = CreateChildAgent(500);
+            var lastChildAgent = CreateChildAgent(500);
 
             var agent = ScriptableObject.CreateInstance<ParallelCompositeAgent>();
             agent.Logger = new ConsoleLogger(Debug.unityLogger.logHandler);
@@ -41,17 +40,23 @@ namespace DeNA.Anjin.Agents
             agent.name = nameof(Run_cancelTask_stopAgent);
             agent.agents = new List<AbstractAgent>() { firstChildAgent, secondChildAgent, lastChildAgent };
 
-            var agentName = agent.GetType().Name;
-            var gameObject = new GameObject(agentName);
+            var gameObject = new GameObject();
             var token = gameObject.GetCancellationTokenOnDestroy();
             var task = agent.Run(token);
-            await UniTask.Delay(TimeSpan.FromSeconds(1), cancellationToken: token);
+            await UniTask.NextFrame();
 
             Object.DestroyImmediate(gameObject);
-            // ReSharper disable once MethodSupportsCancellation
             await UniTask.NextFrame();
 
             Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Canceled));
+
+            await UniTask.Delay(1000); // Consider overhead
+            Assert.That(firstChildAgent.CompleteCount, Is.EqualTo(0));
+            Assert.That(secondChildAgent.CompleteCount, Is.EqualTo(0));
+            Assert.That(lastChildAgent.CompleteCount, Is.EqualTo(0));
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
 
         [Test]
@@ -71,13 +76,16 @@ namespace DeNA.Anjin.Agents
             {
                 var token = cancellationTokenSource.Token;
                 var task = agent.Run(token);
-                await UniTask.Delay(TimeSpan.FromSeconds(2), cancellationToken: token); // Consider overhead
+                await UniTask.Delay(1000); // Consider overhead
 
                 Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Succeeded));
                 Assert.That(firstChildAgent.CompleteCount, Is.EqualTo(1));
                 Assert.That(secondChildAgent.CompleteCount, Is.EqualTo(1));
                 Assert.That(lastChildAgent.CompleteCount, Is.EqualTo(1));
             }
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
 
         [Test]
@@ -97,10 +105,9 @@ namespace DeNA.Anjin.Agents
             {
                 var token = cancellationTokenSource.Token;
                 var task = agent.Run(token);
-                await UniTask.Delay(TimeSpan.FromSeconds(2), cancellationToken: token); // Consider overhead
+                await UniTask.Delay(1000); // Consider overhead
 
                 Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Succeeded));
-                Assert.That(firstChildAgent.Logger, Is.Not.Null);
                 Assert.That(firstChildAgent.Logger, Is.EqualTo(agent.Logger)); // Instances inherited from parent
                 Assert.That(firstChildAgent.Random, Is.Not.Null);
                 Assert.That(firstChildAgent.Random, Is.Not.EqualTo(agent.Random));
@@ -110,6 +117,9 @@ namespace DeNA.Anjin.Agents
                 Assert.That(firstRandomValue, Is.Not.EqualTo(agent.Random.Next()));
                 Assert.That(firstRandomValue, Is.Not.EqualTo(secondChildAgent.Random.Next()));
             }
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
     }
 }

--- a/Tests/Runtime/Agents/RepeatAgentTest.cs
+++ b/Tests/Runtime/Agents/RepeatAgentTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2023 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
-using System;
 using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using DeNA.Anjin.TestDoubles;
@@ -37,17 +36,18 @@ namespace DeNA.Anjin.Agents
             agent.name = nameof(Run_cancelTask_stopAgent);
             agent.agent = childAgent;
 
-            var agentName = agent.GetType().Name;
-            var gameObject = new GameObject(agentName);
+            var gameObject = new GameObject();
             var token = gameObject.GetCancellationTokenOnDestroy();
             var task = agent.Run(token);
-            await UniTask.Delay(TimeSpan.FromMilliseconds(500), cancellationToken: token);
+            await UniTask.NextFrame();
 
             Object.DestroyImmediate(gameObject);
-            // ReSharper disable once MethodSupportsCancellation
             await UniTask.NextFrame();
 
             Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Canceled));
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
 
         [Test]
@@ -61,17 +61,19 @@ namespace DeNA.Anjin.Agents
             agent.name = nameof(Run_cancelTask_stopAgent);
             agent.agent = childAgent;
 
-            var agentName = agent.GetType().Name;
-            var gameObject = new GameObject(agentName);
+            var gameObject = new GameObject();
             var token = gameObject.GetCancellationTokenOnDestroy();
             var task = agent.Run(token);
-            await UniTask.Delay(TimeSpan.FromMilliseconds(500), cancellationToken: token);
+            await UniTask.Delay(500);
 
             Object.DestroyImmediate(gameObject);
-            // ReSharper disable once MethodSupportsCancellation
             await UniTask.NextFrame();
 
+            Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Canceled));
             Assert.That(childAgent.CompleteCount, Is.GreaterThan(2));
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
 
         [Test]
@@ -85,20 +87,20 @@ namespace DeNA.Anjin.Agents
             agent.name = nameof(Run_cancelTask_stopAgent);
             agent.agent = childAgent;
 
-            var agentName = agent.GetType().Name;
-            var gameObject = new GameObject(agentName);
+            var gameObject = new GameObject();
             var token = gameObject.GetCancellationTokenOnDestroy();
             var task = agent.Run(token);
-            await UniTask.Delay(TimeSpan.FromMilliseconds(500), cancellationToken: token);
+            await UniTask.Delay(500);
 
             Object.DestroyImmediate(gameObject);
-            // ReSharper disable once MethodSupportsCancellation
             await UniTask.NextFrame();
 
-            Assert.That(childAgent.Logger, Is.Not.Null);
+            Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Canceled));
             Assert.That(childAgent.Logger, Is.EqualTo(agent.Logger)); // Instances inherited from parent
-            Assert.That(childAgent.Random, Is.Not.Null);
             Assert.That(childAgent.Random, Is.EqualTo(agent.Random)); // Instances inherited from parent
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
     }
 }

--- a/Tests/Runtime/Agents/TimeBombAgentTest.cs
+++ b/Tests/Runtime/Agents/TimeBombAgentTest.cs
@@ -55,6 +55,11 @@ namespace DeNA.Anjin.Agents
 
                 Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Canceled));
             }
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Enter {monkeyAgent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {monkeyAgent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
 
         [Test]
@@ -66,13 +71,16 @@ namespace DeNA.Anjin.Agents
             agent.Logger = new ConsoleLogger(Debug.unityLogger.logHandler);
             agent.Random = new RandomFactory(0).CreateRandom();
 
-            LogAssert.Expect(LogType.Log, "Working agent UGUIMonkeyAgent was cancelled.");
-            LogAssert.Expect(LogType.Log, "Exit TimeBombAgent.Run()");
-
             using (var cts = new CancellationTokenSource())
             {
                 await agent.Run(cts.Token);
             }
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Enter {monkeyAgent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {monkeyAgent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Working agent {monkeyAgent.name} was cancelled.");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
 
         [Test]
@@ -97,6 +105,11 @@ namespace DeNA.Anjin.Agents
                         "Could not receive defuse message `^Never match!$` before the agent terminated."));
                 }
             }
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Enter {monkeyAgent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {monkeyAgent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
     }
 }

--- a/Tests/Runtime/Agents/UGUIMonkeyAgentTest.cs
+++ b/Tests/Runtime/Agents/UGUIMonkeyAgentTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2023 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,16 +38,18 @@ namespace DeNA.Anjin.Agents
             agent.lifespanSec = 0; // Expect indefinite execution
             agent.delayMillis = 100;
 
-            var agentName = agent.GetType().Name;
-            var gameObject = new GameObject(agentName);
+            var gameObject = new GameObject();
             var token = gameObject.GetCancellationTokenOnDestroy();
             var task = agent.Run(token);
-            await UniTask.Delay(TimeSpan.FromSeconds(1), cancellationToken: token);
+            await UniTask.NextFrame();
 
             Object.DestroyImmediate(gameObject);
-            await UniTask.Delay(TimeSpan.FromSeconds(0.5));
+            await UniTask.NextFrame();
 
             Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Canceled));
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
 
         [Test]
@@ -65,11 +66,13 @@ namespace DeNA.Anjin.Agents
             {
                 var token = cancellationTokenSource.Token;
                 var task = agent.Run(token);
-                await UniTask.Delay(TimeSpan.FromSeconds(2),
-                    cancellationToken: token); // Consider overhead
+                await UniTask.Delay(2000); // Consider overhead
 
                 Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Succeeded));
             }
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
 
         [Test]

--- a/Tests/Runtime/Agents/UGUIPlaybackAgentTest.cs
+++ b/Tests/Runtime/Agents/UGUIPlaybackAgentTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2023 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
@@ -37,17 +36,18 @@ namespace DeNA.Anjin.Agents
             agent.recordedJson = AssetDatabase.LoadAssetAtPath<TextAsset>(
                 "Packages/com.dena.anjin/Tests/TestAssets/TapButton1x4.json");
 
-            var agentName = agent.GetType().Name;
-            var gameObject = new GameObject(agentName);
+            var gameObject = new GameObject();
             var token = gameObject.GetCancellationTokenOnDestroy();
             var task = agent.Run(token);
-            await UniTask.Delay(TimeSpan.FromSeconds(1), cancellationToken: token);
+            await UniTask.NextFrame();
 
             Object.DestroyImmediate(gameObject);
-            // ReSharper disable once MethodSupportsCancellation
             await UniTask.NextFrame();
 
             Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Canceled));
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
 
         [Test]
@@ -64,10 +64,13 @@ namespace DeNA.Anjin.Agents
             {
                 var token = cancellationTokenSource.Token;
                 var task = agent.Run(token);
-                await UniTask.Delay(TimeSpan.FromSeconds(2), cancellationToken: token); // Consider overhead
+                await UniTask.Delay(2000); // Consider overhead
 
                 Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Succeeded));
             }
+
+            LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
         }
     }
 }


### PR DESCRIPTION
### Before
Agents do not output exit log if canceled.

### After
Agents output exit log always.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).