### PR TITLE
Fix to remove event listeners on destroying Autopilot object

### DIFF
--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -84,6 +84,22 @@ namespace DeNA.Anjin
             yield return UniTask.ToCoroutine(() => TerminateAsync(ExitCode.Normally));
         }
 
+        private void OnDestroy()
+        {
+            // Clear event listeners.
+            // When play mode is stopped by the user, onDestroy calls without TerminateAsync.
+
+            if (_dispatcher != null)
+            {
+                _dispatcher.Dispose();
+            }
+
+            if (_logMessageHandler != null)
+            {
+                Application.logMessageReceivedThreaded -= _logMessageHandler.HandleLog;
+            }
+        }
+
         /// <summary>
         /// Terminate autopilot
         /// </summary>
@@ -95,16 +111,6 @@ namespace DeNA.Anjin
         public async UniTask TerminateAsync(ExitCode exitCode, string logString = null, string stackTrace = null,
             CancellationToken token = default)
         {
-            if (_dispatcher != null)
-            {
-                _dispatcher.Dispose();
-            }
-
-            if (_logMessageHandler != null)
-            {
-                Application.logMessageReceivedThreaded -= _logMessageHandler.HandleLog;
-            }
-
             if (_state.settings != null && !string.IsNullOrEmpty(_state.settings.junitReportPath))
             {
                 var time = Time.realtimeSinceStartup - _startTime;

--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -46,7 +46,6 @@ namespace DeNA.Anjin
             //       Because some agent can throw an error immediately, so reporter can miss the error if
             //       registering logMessageReceived is placed after DispatchByScene.
             _logMessageHandler = new LogMessageHandler(_settings, _settings.reporter);
-            Application.logMessageReceivedThreaded += _logMessageHandler.HandleLog;
 
             _dispatcher = new AgentDispatcher(_settings, _logger, _randomFactory);
             _dispatcher.DispatchByScene(SceneManager.GetActiveScene());
@@ -96,7 +95,7 @@ namespace DeNA.Anjin
 
             if (_logMessageHandler != null)
             {
-                Application.logMessageReceivedThreaded -= _logMessageHandler.HandleLog;
+                _logMessageHandler.Dispose();
             }
         }
 

--- a/Runtime/Utilities/LogMessageHandler.cs
+++ b/Runtime/Utilities/LogMessageHandler.cs
@@ -1,17 +1,19 @@
 ﻿// Copyright (c) 2023 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
+using System;
 using Cysharp.Threading.Tasks;
 using DeNA.Anjin.Reporters;
 using DeNA.Anjin.Settings;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace DeNA.Anjin.Utilities
 {
     /// <summary>
     /// Log message handling using <c>Application.logMessageReceived</c>.
     /// </summary>
-    public class LogMessageHandler
+    public class LogMessageHandler : IDisposable
     {
         private readonly AutopilotSettings _settings;
         private readonly AbstractReporter _reporter;
@@ -25,6 +27,12 @@ namespace DeNA.Anjin.Utilities
         {
             _settings = settings;
             _reporter = reporter;
+            Application.logMessageReceivedThreaded += this.HandleLog;
+        }
+
+        public void Dispose()
+        {
+            Application.logMessageReceivedThreaded -= this.HandleLog;
         }
 
         /// <summary>


### PR DESCRIPTION
### Problem
Duplicate agent creation.

### Conditions
1. **Stop Play Mode** after Launch autopilot on editor window
2. Re-launch autopilot

### Cause
`SceneManager.sceneLoaded` event listener is not removed. Because it does not call `Autopilot.TerminateAsync` when stopping Play Mode.

### Fix
Remove event listeners on destroying `Autopilot` object.

### Remarks
No way to write effective test code for this change.

### Other changes
Refactor: Fix to add/remove `Application.logMessageReceivedThreaded` event listener on inside `LogMessageHandler`.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).