### PR TITLE
Fix CompositeAgent includes null and itself agent case

### DIFF
--- a/Runtime/Agents/ParallelCompositeAgent.cs
+++ b/Runtime/Agents/ParallelCompositeAgent.cs
@@ -20,12 +20,13 @@ namespace DeNA.Anjin.Agents
             Logger.Log($"Enter {this.name}.Run()");
 
             var tasks = new UniTask[agents.Count];
+            var taskIndex = 0;
 
-            foreach (var (agent, i) in agents.Select((agent, i) => (agent, i)))
+            foreach (var agent in agents.Where(agent => agent != null && agent != this))
             {
                 agent.Logger = Logger;
                 agent.Random = RandomFactory.CreateRandom();
-                tasks[i] = agent.Run(token);
+                tasks[taskIndex++] = agent.Run(token);
             }
 
             try

--- a/Runtime/Agents/ParallelCompositeAgent.cs
+++ b/Runtime/Agents/ParallelCompositeAgent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2023 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
@@ -19,14 +20,13 @@ namespace DeNA.Anjin.Agents
         {
             Logger.Log($"Enter {this.name}.Run()");
 
-            var tasks = new UniTask[agents.Count];
-            var taskIndex = 0;
+            var tasks = new List<UniTask>();
 
             foreach (var agent in agents.Where(agent => agent != null && agent != this))
             {
                 agent.Logger = Logger;
                 agent.Random = RandomFactory.CreateRandom();
-                tasks[taskIndex++] = agent.Run(token);
+                tasks.Add(agent.Run(token));
             }
 
             try

--- a/Runtime/Agents/SerialCompositeAgent.cs
+++ b/Runtime/Agents/SerialCompositeAgent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2023 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
+using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -20,7 +21,7 @@ namespace DeNA.Anjin.Agents
 
             try
             {
-                foreach (var agent in agents)
+                foreach (var agent in agents.Where(agent => agent != null && agent != this))
                 {
                     agent.Logger = Logger;
                     agent.Random = RandomFactory.CreateRandom();

--- a/Tests/Runtime/Agents/ParallelCompositeAgentTest.cs
+++ b/Tests/Runtime/Agents/ParallelCompositeAgentTest.cs
@@ -12,6 +12,8 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 
+// ReSharper disable MethodSupportsCancellation
+
 namespace DeNA.Anjin.Agents
 {
     [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
@@ -120,6 +122,56 @@ namespace DeNA.Anjin.Agents
 
             LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
             LogAssert.Expect(LogType.Log, $"Exit {agent.name}.Run()");
+        }
+
+        [Test]
+        public async Task Run_IncludesNull_IgnoreNull()
+        {
+            var firstChildAgent = CreateChildAgent(500);
+            var lastChildAgent = CreateChildAgent(500);
+
+            var sut = ScriptableObject.CreateInstance<ParallelCompositeAgent>();
+            sut.Logger = new ConsoleLogger(Debug.unityLogger.logHandler);
+            sut.Random = new RandomFactory(0).CreateRandom();
+            sut.name = nameof(Run_lifespanPassed_stopAgent);
+            sut.agents = new List<AbstractAgent>() { firstChildAgent, null, lastChildAgent };
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                var token = cancellationTokenSource.Token;
+                await sut.Run(token);
+            }
+
+            Assert.That(firstChildAgent.CompleteCount, Is.EqualTo(1));
+            Assert.That(lastChildAgent.CompleteCount, Is.EqualTo(1));
+
+            LogAssert.Expect(LogType.Log, $"Enter {sut.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {sut.name}.Run()");
+        }
+
+        [Test]
+        public async Task Run_NestingAgent_IgnoreNested()
+        {
+            var firstChildAgent = CreateChildAgent(500);
+            var lastChildAgent = CreateChildAgent(500);
+
+            var sut = ScriptableObject.CreateInstance<ParallelCompositeAgent>();
+            sut.Logger = new ConsoleLogger(Debug.unityLogger.logHandler);
+            sut.Random = new RandomFactory(0).CreateRandom();
+            sut.name = nameof(Run_lifespanPassed_stopAgent);
+            sut.agents = new List<AbstractAgent>() { firstChildAgent, sut, lastChildAgent };
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                var token = cancellationTokenSource.Token;
+                await sut.Run(token);
+            }
+
+            Assert.That(firstChildAgent.CompleteCount, Is.EqualTo(1));
+            Assert.That(lastChildAgent.CompleteCount, Is.EqualTo(1));
+
+            LogAssert.Expect(LogType.Log, $"Enter {sut.name}.Run()");
+            LogAssert.Expect(LogType.Log, $"Exit {sut.name}.Run()");
         }
     }
 }


### PR DESCRIPTION
### Problem
1. NullReferenceException
2. Freeze Unity editor

### Conditions
1. CompositeAgent includes "None" entity
2. CompositeAgent includes itself entity

### Cause
Not excluding null and itself.

### Fix
Excluding null and itself.

---
### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).