### PR TITLE
Upgrade test-helper.monkey to v0.12.0 (Optimize logging)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "changelogUrl": "https://github.com/DeNA/Anjin/releases",
   "dependencies": {
     "com.cysharp.unitask": "2.3.3",
-    "com.nowsprinting.test-helper.monkey": "0.11.0",
+    "com.nowsprinting.test-helper.monkey": "0.12.0",
     "com.nowsprinting.test-helper.random": "0.3.0",
     "com.unity.automated-testing": "0.8.1-preview.2"
   },

--- a/package.json
+++ b/package.json
@@ -7,23 +7,22 @@
   "dependencies": {
     "com.cysharp.unitask": "2.3.3",
     "com.nowsprinting.test-helper.monkey": "0.12.0",
-    "com.nowsprinting.test-helper.random": "0.3.0",
     "com.unity.automated-testing": "0.8.1-preview.2"
   },
   "displayName": "Anjin",
   "documentationUrl": "https://github.com/DeNA/Anjin/blob/master/README.md",
   "files": [
-    "Annotations",
-    "Annotations*",
-    "Documentation~",
-    "Editor",
-    "Editor*",
-    "Runtime",
-    "Runtime*",
-    "Tests",
-    "Tests*",
+    "Annotations/",
+    "Annotations.meta",
+    "Documentation~/",
+    "Editor/",
+    "Editor.meta",
+    "Runtime/",
+    "Runtime.meta",
+    "Tests/",
+    "Tests.meta",
+    "LICENSE.txt*",
     "package.json*",
-    "LICENSE*",
     "README*"
   ],
   "keywords": [


### PR DESCRIPTION
### Changes
- Upgrade test-helper.monkey package to [v0.12.0](https://github.com/nowsprinting/test-helper.monkey/releases/tag/v0.12.0) (Optimize logging)
- Optimize package.json

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).