### PR TITLE
Add mark stack traces with CDATA in JUnit XML report

### DIFF
--- a/Runtime/Utilities/JUnitReporter.cs
+++ b/Runtime/Utilities/JUnitReporter.cs
@@ -74,12 +74,12 @@ namespace DeNA.Anjin.Utilities
         private const string ErrorElement = @"
                                     <error message=""{0}""
                                            type=""""
-                                            >{1}</error>";
+                                            ><![CDATA[{1}]]></error>";
 
         private const string FailureElement = @"
                                     <failure message=""{0}""
                                              type=""""
-                                            >{1}</failure>";
+                                            ><![CDATA[{1}]]></failure>";
 
         // XML format from: https://github.com/jenkinsci/benchmark-plugin/blob/master/doc/JUnit%20format/JUnit.txt
     }

--- a/Tests/Runtime/Utilities/JUnitReporterTest.cs
+++ b/Tests/Runtime/Utilities/JUnitReporterTest.cs
@@ -95,7 +95,7 @@ namespace DeNA.Anjin.Utilities
                                     >
                                     <error message=""Error message!""
                                            type=""""
-                                            >Stack trace!</error>
+                                            ><![CDATA[Stack trace!]]></error>
                         </testcase>
             </testsuite>
 </testsuites>"));
@@ -123,7 +123,7 @@ namespace DeNA.Anjin.Utilities
                                     >
                                     <failure message=""Failure message!""
                                              type=""""
-                                            >Stack trace!!</failure>
+                                            ><![CDATA[Stack trace!!]]></failure>
                         </testcase>
             </testsuite>
 </testsuites>"));


### PR DESCRIPTION
When generics are included in the stack trace, `<` and `>` are inserted.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).