### PR TITLE
Not to send body when stack-trace is empty

### DIFF
--- a/Runtime/Reporters/AbstractReporter.cs
+++ b/Runtime/Reporters/AbstractReporter.cs
@@ -3,7 +3,6 @@
 
 using System.Threading;
 using Cysharp.Threading.Tasks;
-using DeNA.Anjin.Settings;
 using UnityEngine;
 
 namespace DeNA.Anjin.Reporters
@@ -16,7 +15,6 @@ namespace DeNA.Anjin.Reporters
         /// <summary>
         /// Post report log message, stacktrace and screenshot
         /// </summary>
-        /// <param name="settings">Autopilot settings</param>
         /// <param name="logString">Log message</param>
         /// <param name="stackTrace">Stack trace</param>
         /// <param name="type">Log message type</param>
@@ -24,7 +22,6 @@ namespace DeNA.Anjin.Reporters
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         public abstract UniTask PostReportAsync(
-            AutopilotSettings settings,
             string logString,
             string stackTrace,
             LogType type,

--- a/Runtime/Reporters/CompositeReporter.cs
+++ b/Runtime/Reporters/CompositeReporter.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
-using DeNA.Anjin.Settings;
 using UnityEngine;
 
 namespace DeNA.Anjin.Reporters
@@ -24,7 +23,6 @@ namespace DeNA.Anjin.Reporters
 
         /// <inheritdoc />
         public override async UniTask PostReportAsync(
-            AutopilotSettings settings,
             string logString,
             string stackTrace,
             LogType type,
@@ -36,7 +34,7 @@ namespace DeNA.Anjin.Reporters
                 reporters
                     .Where(r => r != this && r != null)
                     .Select(
-                        r => r.PostReportAsync(settings, logString, stackTrace, type, withScreenshot, cancellationToken)
+                        r => r.PostReportAsync(logString, stackTrace, type, withScreenshot, cancellationToken)
                     )
             );
         }

--- a/Runtime/Reporters/SlackMessageSender.cs
+++ b/Runtime/Reporters/SlackMessageSender.cs
@@ -95,7 +95,7 @@ namespace DeNA.Anjin.Reporters
             if (withScreenshot)
             {
                 var coroutineRunner = new GameObject().AddComponent<CoroutineRunner>();
-                await UniTask.WaitForEndOfFrame(coroutineRunner);
+                await UniTask.WaitForEndOfFrame(coroutineRunner, cancellationToken);
                 Object.Destroy(coroutineRunner);
 
                 var screenshot = ScreenCapture.CaptureScreenshotAsTexture();
@@ -107,7 +107,8 @@ namespace DeNA.Anjin.Reporters
                     slackToken,
                     slackChannel,
                     withoutAlpha.EncodeToPNG(),
-                    postTitleTask.Ts
+                    postTitleTask.Ts,
+                    cancellationToken
                 );
                 if (!postScreenshotTask.Success)
                 {
@@ -115,8 +116,11 @@ namespace DeNA.Anjin.Reporters
                 }
             }
 
-            var body = Body(logString, stackTrace);
-            await _slackAPI.Post(slackToken, slackChannel, body, postTitleTask.Ts);
+            if (stackTrace != null && stackTrace.Length > 0)
+            {
+                var body = Body(logString, stackTrace);
+                await _slackAPI.Post(slackToken, slackChannel, body, postTitleTask.Ts, cancellationToken);
+            }
         }
 
 

--- a/Runtime/Settings/AutopilotSettings.cs
+++ b/Runtime/Settings/AutopilotSettings.cs
@@ -163,16 +163,12 @@ namespace DeNA.Anjin.Settings
 
             if (args.SlackToken.IsCaptured())
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 slackToken = args.SlackToken.Value();
-#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             if (args.SlackChannels.IsCaptured())
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 slackChannels = args.SlackChannels.Value();
-#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
     }

--- a/Runtime/Utilities/LogMessageHandler.cs
+++ b/Runtime/Utilities/LogMessageHandler.cs
@@ -53,7 +53,7 @@ namespace DeNA.Anjin.Utilities
 
             if (_reporter != null)
             {
-                await _reporter.PostReportAsync(_settings, logString, stackTrace, type, true);
+                await _reporter.PostReportAsync(logString, stackTrace, type, true);
             }
 
             var autopilot = Object.FindObjectOfType<Autopilot>();

--- a/Tests/Runtime/TestDoubles/SpyReporter.cs
+++ b/Tests/Runtime/TestDoubles/SpyReporter.cs
@@ -19,7 +19,6 @@ namespace DeNA.Anjin.TestDoubles
         public List<Dictionary<string, string>> Arguments { get; } = new List<Dictionary<string, string>>();
         
         public override async UniTask PostReportAsync(
-            AutopilotSettings settings,
             string logString,
             string stackTrace,
             LogType type,
@@ -30,7 +29,6 @@ namespace DeNA.Anjin.TestDoubles
             Debug.Log("Reporter called");
             Arguments.Add(new Dictionary<string, string>
             {
-                {"settings", settings.ToString()},
                 {"logString", logString},
                 {"stackTrace", stackTrace},
                 {"type", type.ToString()},


### PR DESCRIPTION
### Changes
- Fix not to send body when stack-trace is empty
- Remove suppress diagnostic for obsolete fields
- Remove `AutopilotSettings` from parameter of `PostReportAsync`

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).