### PR TITLE
Add command line argument -FILE_LOGGER_OUTPUT_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,8 +447,10 @@ A Reporter that post report to Slack.
 The instance of this Reporter (.asset file) can have the following settings.
 
 <dl>
-  <dt>Slack Token</dt><dd>Web API token used for Slack notifications (if omitted, no notifications will be sent)</dd>
-  <dt>Slack Channels</dt><dd>Channels to send Slack notifications (not notified if omitted. Multiple channels can be specified by separating them with commas)</dd>
+  <dt>Slack Token</dt><dd>Web API token used for Slack notifications. If omitted, no notifications will be sent.
+        This setting can be overwritten with the command line argument <code>-SLACK_TOKEN</code>.</dd>
+  <dt>Slack Channels</dt><dd>Channels to send Slack notifications. If omitted, not notified. Multiple channels can be specified by separating them with commas.
+        This setting can be overwritten with the command line argument <code>-SLACK_CHANNELS</code>.</dd>
   <dt>Mention Sub Team IDs</dt><dd>Comma Separated Team IDs to Mention in Slack Notification Message</dd>
   <dt>Add Here In Slack Message</dt><dd>Add @here to Slack notification message. Default is off</dd>
 </dl>

--- a/README.md
+++ b/README.md
@@ -416,7 +416,8 @@ A Logger that outputs to a specified file.
 The instance of this Logger (.asset file) can have the following settings.
 
 <dl>
-  <dt>Output File Path</dt><dd>Log output file path. Specify relative path from project root or absolute path. When run on player, it will be the <code>Application.persistentDataPath</code>.</dd>
+  <dt>Output File Path</dt><dd>Log output file path. Specify relative path from project root or absolute path. When run on player, it will be the <code>Application.persistentDataPath</code>.
+        This setting can be overwritten with the command line argument <code>-FILE_LOGGER_OUTPUT_PATH</code>, but if multiple File Loggers are defined, they will all be overwritten with the same path.</dd>
   <dt>Filter LogType</dt><dd>To selective enable debug log message</dd>
   <dt>Timestamp</dt><dd>Output timestamp to log entities</dd>
 </dl>

--- a/README_ja.md
+++ b/README_ja.md
@@ -420,7 +420,8 @@ SerialCompositeAgentと組み合わせることで、シナリオを何周もし
 このロガーのインスタンス（.assetファイル）には以下を設定できます。
 
 <dl>
-  <dt>出力ファイルパス</dt><dd>ログ出力ファイルのパス。プロジェクトルートからの相対パスまたは絶対パスを指定します。プレイヤー実行では相対パスの起点は <code>Application.persistentDataPath</code> になります。</dd>
+  <dt>出力ファイルパス</dt><dd>ログ出力ファイルのパス。プロジェクトルートからの相対パスまたは絶対パスを指定します。プレイヤー実行では相対パスの起点は <code>Application.persistentDataPath</code> になります。
+        コマンドライン引数 <code>-FILE_LOGGER_OUTPUT_PATH</code> で上書きできますが、複数のFileLoggerを定義しているときに指定すると、すべての出力パスが上書きされますので注意してください。</dd>
   <dt>フィルタリングLogType</dt><dd>選択したLogType以上のログ出力のみを有効にします</dd>
   <dt>タイムスタンプを出力</dt><dd>ログエンティティにタイムスタンプを出力します</dd>
 </dl>

--- a/README_ja.md
+++ b/README_ja.md
@@ -451,8 +451,8 @@ Slackにレポート送信するレポータです。
 このレポータのインスタンス（.assetファイル）には以下を設定できます。
 
 <dl>
-  <dt>Slack Token</dt><dd>Slack通知に使用するWeb APIトークン（省略時は通知されない）</dd>
-  <dt>Slack Channels</dt><dd>Slack通知を送るチャンネル（省略時は通知されない。カンマ区切りで複数指定対応）</dd>
+  <dt>Slack Token</dt><dd>Slack通知に使用するWeb APIトークン（省略時は通知されない）。コマンドライン引数 <code>-SLACK_TOKEN</code> で上書きできます。</dd>
+  <dt>Slack Channels</dt><dd>Slack通知を送るチャンネル（省略時は通知されない）。カンマ区切りで複数指定できます。コマンドライン引数 <code>-SLACK_CHANNELS</code> で上書きできます。</dd>
   <dt>Mention Sub Team IDs</dt><dd>Slack通知メッセージでメンションするチームのIDをカンマ区切りで指定します</dd>
   <dt>Add Here In Slack Message</dt><dd>Slack通知メッセージに@hereを付けます。デフォルトはoff</dd>
 </dl>

--- a/Runtime/Loggers/FileLoggerAsset.cs
+++ b/Runtime/Loggers/FileLoggerAsset.cs
@@ -48,8 +48,13 @@ namespace DeNA.Anjin.Loggers
                     return _logger;
                 }
 
+                if (string.IsNullOrEmpty(outputPath))
+                {
+                    throw new InvalidOperationException("outputPath is not set.");
+                }
+
                 var directory = Path.GetDirectoryName(outputPath);
-                if (directory != null && !Directory.Exists(directory))
+                if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
                 {
                     Directory.CreateDirectory(directory);
                 }

--- a/Runtime/Loggers/FileLoggerAsset.cs
+++ b/Runtime/Loggers/FileLoggerAsset.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using DeNA.Anjin.Settings;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -48,18 +49,20 @@ namespace DeNA.Anjin.Loggers
                     return _logger;
                 }
 
-                if (string.IsNullOrEmpty(outputPath))
+                var args = new Arguments();
+                var path = args.FileLoggerOutputPath.IsCaptured() ? args.FileLoggerOutputPath.Value() : outputPath;
+                if (string.IsNullOrEmpty(path))
                 {
                     throw new InvalidOperationException("outputPath is not set.");
                 }
 
-                var directory = Path.GetDirectoryName(outputPath);
+                var directory = Path.GetDirectoryName(path);
                 if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
                 {
                     Directory.CreateDirectory(directory);
                 }
 
-                _handler = new FileLogHandler(outputPath, timestamp);
+                _handler = new FileLogHandler(path, timestamp);
                 _logger = new Logger(_handler) { filterLogType = filterLogType };
                 return _logger;
             }

--- a/Runtime/Settings/Arguments.cs
+++ b/Runtime/Settings/Arguments.cs
@@ -46,6 +46,14 @@ namespace DeNA.Anjin.Settings
         public virtual IArgument<string> JUnitReportPath => new Argument<string>("JUNIT_REPORT_PATH");
 
         /// <summary>
+        /// Specifies the output path using <c>FileLoggerAsset</c> (optional).
+        ///
+        /// This argument is not used in <c>AutopilotSettings</c>, Used in <c>FileLoggerAsset</c>.
+        /// Note: If multiple FileLoggers are defined, they will all be overwritten with the same path.
+        /// </summary>
+        public virtual IArgument<string> FileLoggerOutputPath => new Argument<string>("FILE_LOGGER_OUTPUT_PATH");
+
+        /// <summary>
         /// Specifies the enable/disable handling Exception (optional).
         /// </summary>
         public virtual IArgument<bool> HandleException => new Argument<bool>("HANDLE_EXCEPTION");

--- a/Tests/Runtime/Loggers/FileLoggerAssetTest.cs
+++ b/Tests/Runtime/Loggers/FileLoggerAssetTest.cs
@@ -36,7 +36,7 @@ namespace DeNA.Anjin.Loggers
         }
 
         [Test, Order(0)]
-        public async Task GetLoggerImpl_DirectoryDoesNotExist_CreateDirectoryAndWriteToFile()
+        public async Task GetLogger_DirectoryDoesNotExist_CreateDirectoryAndWriteToFile()
         {
             if (Directory.Exists(LogsDirectoryPath))
             {
@@ -58,7 +58,7 @@ namespace DeNA.Anjin.Loggers
         }
 
         [Test]
-        public async Task GetLoggerImpl_FileExists_OverwrittenToFile()
+        public async Task GetLogger_FileExists_OverwrittenToFile()
         {
             var message = TestContext.CurrentContext.Test.Name;
             var path = GetOutputPath();
@@ -74,6 +74,39 @@ namespace DeNA.Anjin.Loggers
 
             var actual = File.ReadAllText(path);
             Assert.That(actual, Is.EqualTo(message + Environment.NewLine));
+        }
+
+        [Test]
+        public void GetLogger_OutputPathIsEmpty_ThrowsException()
+        {
+            var message = TestContext.CurrentContext.Test.Name;
+            var path = string.Empty;
+            var sut = ScriptableObject.CreateInstance<FileLoggerAsset>();
+            sut.outputPath = path;
+            sut.timestamp = false;
+
+            Assert.That(() => sut.Logger, Throws.TypeOf<InvalidOperationException>()
+                .And.Message.EqualTo("outputPath is not set."));
+        }
+
+        [Test]
+        public async Task GetLogger_OutputPathWithoutDirectory_WriteToFile()
+        {
+            var message = TestContext.CurrentContext.Test.Name;
+            var path = $"{TestContext.CurrentContext.Test.Name}.log"; // without directory
+            var sut = ScriptableObject.CreateInstance<FileLoggerAsset>();
+            sut.outputPath = path;
+            sut.timestamp = false;
+
+            sut.Logger.Log(message);
+            sut.Dispose();
+            await Task.Yield();
+
+            var actual = File.ReadAllText(path);
+            Assert.That(actual, Is.EqualTo(message + Environment.NewLine));
+
+            // teardown
+            File.Delete(path);
         }
 
         [Test]


### PR DESCRIPTION
### Changes
- Add command line argument `-FILE_LOGGER_OUTPUT_PATH`. Overwrite the `outputPath` of `FileLogger`
- Fix READMEs for `SlackReporter`
- Fix case of `outputPath` without directory
- Fix case of `outputPath` is not set

### Priority
It's a low priority for me.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).