### PR TITLE
Crean logger instances when launch autopilot

### DIFF
--- a/Runtime/Loggers/ConsoleLoggerAsset.cs
+++ b/Runtime/Loggers/ConsoleLoggerAsset.cs
@@ -2,6 +2,10 @@
 // This software is released under the MIT License.
 
 using UnityEngine;
+#if UNITY_EDITOR
+using DeNA.Anjin.Attributes;
+using UnityEditor;
+#endif
 
 namespace DeNA.Anjin.Loggers
 {
@@ -39,5 +43,17 @@ namespace DeNA.Anjin.Loggers
         {
             // Nothing to dispose.
         }
+
+#if UNITY_EDITOR
+        [InitializeOnLaunchAutopilot]
+        public static void ResetLoggers()
+        {
+            foreach (var guid in AssetDatabase.FindAssets($"t:{nameof(ConsoleLoggerAsset)}"))
+            {
+                var so = AssetDatabase.LoadAssetAtPath<ConsoleLoggerAsset>(AssetDatabase.GUIDToAssetPath(guid));
+                so._logger = null;
+            }
+        }
+#endif
     }
 }

--- a/Runtime/Loggers/ConsoleLoggerAsset.cs
+++ b/Runtime/Loggers/ConsoleLoggerAsset.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) 2023-2024 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
+using DeNA.Anjin.Attributes;
 using UnityEngine;
 #if UNITY_EDITOR
-using DeNA.Anjin.Attributes;
 using UnityEditor;
 #endif
 
@@ -44,16 +44,23 @@ namespace DeNA.Anjin.Loggers
             // Nothing to dispose.
         }
 
-#if UNITY_EDITOR
         [InitializeOnLaunchAutopilot]
         public static void ResetLoggers()
         {
+            // Reset runtime instances
+            var loggerAssets = FindObjectsOfType<ConsoleLoggerAsset>();
+            foreach (var current in loggerAssets)
+            {
+                current._logger = null;
+            }
+#if UNITY_EDITOR
+            // Reset asset files (in Editor only)
             foreach (var guid in AssetDatabase.FindAssets($"t:{nameof(ConsoleLoggerAsset)}"))
             {
                 var so = AssetDatabase.LoadAssetAtPath<ConsoleLoggerAsset>(AssetDatabase.GUIDToAssetPath(guid));
                 so._logger = null;
             }
-        }
 #endif
+        }
     }
 }

--- a/Runtime/Loggers/FileLoggerAsset.cs
+++ b/Runtime/Loggers/FileLoggerAsset.cs
@@ -3,11 +3,11 @@
 
 using System;
 using System.IO;
+using DeNA.Anjin.Attributes;
 using DeNA.Anjin.Settings;
 using UnityEngine;
 using Object = UnityEngine.Object;
 #if UNITY_EDITOR
-using DeNA.Anjin.Attributes;
 using UnityEditor;
 #endif
 
@@ -150,10 +150,19 @@ namespace DeNA.Anjin.Loggers
             }
         }
 
-#if UNITY_EDITOR
         [InitializeOnLaunchAutopilot]
         public static void ResetLoggers()
         {
+            // Reset runtime instances
+            var loggerAssets = FindObjectsOfType<FileLoggerAsset>();
+            foreach (var current in loggerAssets)
+            {
+                current._handler?.Dispose();
+                current._handler = null;
+                current._logger = null;
+            }
+#if UNITY_EDITOR
+            // Reset asset files (in Editor only)
             foreach (var guid in AssetDatabase.FindAssets($"t:{nameof(FileLoggerAsset)}"))
             {
                 var so = AssetDatabase.LoadAssetAtPath<FileLoggerAsset>(AssetDatabase.GUIDToAssetPath(guid));
@@ -161,7 +170,7 @@ namespace DeNA.Anjin.Loggers
                 so._handler = null;
                 so._logger = null;
             }
-        }
 #endif
+        }
     }
 }

--- a/Runtime/Loggers/FileLoggerAsset.cs
+++ b/Runtime/Loggers/FileLoggerAsset.cs
@@ -6,6 +6,10 @@ using System.IO;
 using DeNA.Anjin.Settings;
 using UnityEngine;
 using Object = UnityEngine.Object;
+#if UNITY_EDITOR
+using DeNA.Anjin.Attributes;
+using UnityEditor;
+#endif
 
 namespace DeNA.Anjin.Loggers
 {
@@ -145,5 +149,19 @@ namespace DeNA.Anjin.Loggers
                 _disposed = true;
             }
         }
+
+#if UNITY_EDITOR
+        [InitializeOnLaunchAutopilot]
+        public static void ResetLoggers()
+        {
+            foreach (var guid in AssetDatabase.FindAssets($"t:{nameof(FileLoggerAsset)}"))
+            {
+                var so = AssetDatabase.LoadAssetAtPath<FileLoggerAsset>(AssetDatabase.GUIDToAssetPath(guid));
+                so._handler?.Dispose();
+                so._handler = null;
+                so._logger = null;
+            }
+        }
+#endif
     }
 }

--- a/Tests/Runtime/Loggers/ConsoleLoggerAssetTest.cs
+++ b/Tests/Runtime/Loggers/ConsoleLoggerAssetTest.cs
@@ -4,6 +4,9 @@
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace DeNA.Anjin.Loggers
 {
@@ -36,6 +39,42 @@ namespace DeNA.Anjin.Loggers
 
             LogAssert.Expect(logType, message);
             LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void ResetLoggers_InstanceOnly_ResetLoggerAsset()
+        {
+            var sut = ScriptableObject.CreateInstance<ConsoleLoggerAsset>();
+            sut.filterLogType = LogType.Warning;
+            sut.Logger.Log("Before reset");
+            sut.Dispose();
+            Assume.That(sut.Logger.filterLogType, Is.EqualTo(LogType.Warning));
+
+            ConsoleLoggerAsset.ResetLoggers(); // Called when on launch autopilot
+
+            sut.filterLogType = LogType.Error;
+            sut.Logger.Log("After reset");
+            sut.Dispose();
+            Assert.That(sut.Logger.filterLogType, Is.EqualTo(LogType.Error));
+        }
+
+        [Test]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+        public void ResetLoggers_FromAssetFile_ResetLoggerAsset()
+        {
+#if UNITY_EDITOR
+            var sut = AssetDatabase.LoadAssetAtPath<ConsoleLoggerAsset>(
+                "Packages/com.dena.anjin/Tests/TestAssets/ConsoleLogger.asset");
+            sut.Logger.Log("Before reset");
+            sut.Dispose();
+            Assume.That(sut.Logger.filterLogType, Is.EqualTo(LogType.Warning));
+#endif
+            ConsoleLoggerAsset.ResetLoggers(); // Called when on launch autopilot
+
+            sut.filterLogType = LogType.Error;
+            sut.Logger.Log("After reset");
+            sut.Dispose();
+            Assert.That(sut.Logger.filterLogType, Is.EqualTo(LogType.Error));
         }
     }
 }

--- a/Tests/TestAssets/ConsoleLogger.asset
+++ b/Tests/TestAssets/ConsoleLogger.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5b0f8b0450fb478d95fe8ea52ea83ff, type: 3}
+  m_Name: ConsoleLogger
+  m_EditorClassIdentifier: 
+  description: 
+  filterLogType: 2

--- a/Tests/TestAssets/ConsoleLogger.asset.meta
+++ b/Tests/TestAssets/ConsoleLogger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e454b698282bc4833aa7dffd78ae22b4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/TestAssets/FileLogger.asset
+++ b/Tests/TestAssets/FileLogger.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1efc191684b0450db1298fe7a4c4f1b2, type: 3}
+  m_Name: FileLogger
+  m_EditorClassIdentifier: 
+  description: 
+  outputPath: Logs/FileLoggerTest.log
+  filterLogType: 2
+  timestamp: 1

--- a/Tests/TestAssets/FileLogger.asset.meta
+++ b/Tests/TestAssets/FileLogger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4915b88d8f09041bba3ab87d99e0bc90
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Changes
Crean logger asset instances when launching autopilot.

This change will fix the following problems:

- Not reflected changes in logger settings
- FileLogger: No output file generated

Conditions:

Turn off "Reload Domain" (Project settings > Enter Play Mode Options).
And running the game more than once while the Unity editor is running.

### Priority
It's a low priority for me.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).