### PR TITLE
Fix expression to work with Unity 2020 or lower

### DIFF
--- a/Runtime/Utilities/LogMessageHandler.cs
+++ b/Runtime/Utilities/LogMessageHandler.cs
@@ -116,7 +116,7 @@ namespace DeNA.Anjin.Utilities
 
         private static List<Regex> CreateIgnoreMessageRegexes(AutopilotSettings settings)
         {
-            List<Regex> regexs = new();
+            var regexs = new List<Regex>();
             foreach (var message in settings.ignoreMessages)
             {
                 Regex pattern;


### PR DESCRIPTION
### Changes
Fix the `new` expression to work with Unity 2020 or lower.

refs #67 

### Priority
It's a low priority for me.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).