### PR TITLE
Add `@stable` virtual dist-tag when installing test-framework package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ create_project:
 	  -batchmode \
 	  -quit
 	touch UnityProject~/Assets/.gitkeep
-	openupm -c $(PROJECT_HOME) add -f com.unity.test-framework
+	openupm -c $(PROJECT_HOME) add -f com.unity.test-framework@stable
 	openupm -c $(PROJECT_HOME) add -f com.unity.testtools.codecoverage
 	openupm -c $(PROJECT_HOME) add -f com.cysharp.unitask
 	openupm -c $(PROJECT_HOME) add -f com.nowsprinting.test-helper.monkey

--- a/Makefile
+++ b/Makefile
@@ -96,13 +96,13 @@ create_project:
 	  -createProject $(PROJECT_HOME) \
 	  -batchmode \
 	  -quit
-	touch UnityProject~/Assets/.gitkeep
-	openupm -c $(PROJECT_HOME) add -f com.unity.test-framework@stable
-	openupm -c $(PROJECT_HOME) add -f com.unity.testtools.codecoverage
-	openupm -c $(PROJECT_HOME) add -f com.cysharp.unitask
-	openupm -c $(PROJECT_HOME) add -f com.nowsprinting.test-helper.monkey
-	openupm -c $(PROJECT_HOME) add -f com.nowsprinting.test-helper.random
-	openupm -c $(PROJECT_HOME) add -ft $(PACKAGE_NAME)@file:../../
+	touch $(PROJECT_HOME)/Assets/.gitkeep
+	openupm add -c $(PROJECT_HOME) -f com.unity.test-framework@stable
+	openupm add -c $(PROJECT_HOME) -f com.unity.testtools.codecoverage
+	openupm add -c $(PROJECT_HOME) -f com.cysharp.unitask
+	openupm add -c $(PROJECT_HOME) -f com.nowsprinting.test-helper.monkey
+	openupm add -c $(PROJECT_HOME) -f com.nowsprinting.test-helper.random
+	openupm add -c $(PROJECT_HOME) -ft $(PACKAGE_NAME)@file:../../
 
 .PHONY: remove_project
 remove_project:


### PR DESCRIPTION
### Changes

#### 1. Add `@stable` virtual dist-tag when installing test-framework package

After July 2024, specifying the `@latest` dist-tag (default) will install the test-framework package v2.
`@stable` virtual dist-tag is support from opeupm-cli v4.3.0 or later.
see: https://github.com/openupm/openupm-cli/issues/395

#### 2. Mod openupm command option

`-c` option has been changed from global to local option of add/remove subcommands.
see: https://github.com/openupm/openupm-cli/discussions/408


### Priority

It's a low priority for me.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).