### PR TITLE
Change UGUIMonkeyAgent default screenshot filename strategy to TwoTieredCounterStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ Note that it is convenient to set the `[CreateAssetMenu]` attribute to create an
 
 ### Game title-specific pre-processing
 
-If your title requires its own initialization process, add the `InitializeOnLaunchAutopilot` attribute to the `public static` method that does the initialization.
+If your title requires its own initialization process, add the `InitializeOnLaunchAutopilot` attribute to the `static` method that does the initialization.
 An added method is called from the autopilot launch process.
 
 ```csharp
@@ -496,7 +496,7 @@ Async methods are also supported.
 
 ```csharp
 [InitializeOnLaunchAutopilot]
-public static async UniTask InitializeOnLaunchAutopilotMethod()
+private static async UniTask InitializeOnLaunchAutopilotMethod()
 {
     // initialize code for your game.
 }

--- a/README_ja.md
+++ b/README_ja.md
@@ -484,7 +484,7 @@ Assembly Definition File (asmdef) のAuto Referencedをoff、Define Constraints�
 
 ### タイトル独自事前処理
 
-タイトル独自の初期化処理が必要な場合、初期化を行なう `public static` メソッドに `InitializeOnLaunchAutopilot` 属性を付与してください。
+タイトル独自の初期化処理が必要な場合、初期化を行なう `static` メソッドに `InitializeOnLaunchAutopilot` 属性を付与してください。
 オートパイロットの起動処理の中でメソッドを呼び出します。
 
 ```csharp
@@ -499,7 +499,7 @@ public static void InitializeOnLaunchAutopilotMethod()
 
 ```csharp
 [InitializeOnLaunchAutopilot]
-public static async UniTask InitializeOnLaunchAutopilotMethod()
+private static async UniTask InitializeOnLaunchAutopilotMethod()
 {
     // プロジェクト固有の初期化処理
 }

--- a/Runtime/Agents/UGUIMonkeyAgent.cs
+++ b/Runtime/Agents/UGUIMonkeyAgent.cs
@@ -6,11 +6,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using DeNA.Anjin.Strategies;
 using TestHelper.Monkey;
 using TestHelper.Monkey.Annotations.Enums;
 using TestHelper.Monkey.Operators;
 using TestHelper.Monkey.Random;
-using TestHelper.Monkey.ScreenshotFilenameStrategies;
 using TestHelper.Random;
 using UnityEngine;
 
@@ -112,7 +112,7 @@ namespace DeNA.Anjin.Agents
                     ? new ScreenshotOptions
                     {
                         Directory = defaultScreenshotDirectory ? null : screenshotDirectory,
-                        FilenameStrategy = new CounterBasedStrategy(
+                        FilenameStrategy = new TwoTieredCounterStrategy(
                             defaultScreenshotFilenamePrefix ? this.name : screenshotFilenamePrefix
                         ),
                         SuperSize = screenshotSuperSize,

--- a/Runtime/Launcher.cs
+++ b/Runtime/Launcher.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using DeNA.Anjin.Attributes;
@@ -59,9 +60,10 @@ namespace DeNA.Anjin
 
         private static async UniTask CallAttachedInitializeOnLaunchAutopilotAttributeMethods()
         {
+            const BindingFlags MethodBindingFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
             foreach (var methodInfo in AppDomain.CurrentDomain.GetAssemblies()
                          .SelectMany(x => x.GetTypes())
-                         .SelectMany(x => x.GetMethods())
+                         .SelectMany(x => x.GetMethods(MethodBindingFlags))
                          .Where(x => x.GetCustomAttributes(typeof(InitializeOnLaunchAutopilotAttribute), false).Any()))
             {
                 switch (methodInfo.ReturnType.Name)

--- a/Runtime/Strategies.meta
+++ b/Runtime/Strategies.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d1f6e22d70b842a08f921cbb41ea0cbb
+timeCreated: 1729491929

--- a/Runtime/Strategies/TwoTieredCounterStrategy.cs
+++ b/Runtime/Strategies/TwoTieredCounterStrategy.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2023-2024 DeNA Co., Ltd.
+// This software is released under the MIT License.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using DeNA.Anjin.Attributes;
+using TestHelper.Monkey.ScreenshotFilenameStrategies;
+
+namespace DeNA.Anjin.Strategies
+{
+    /// <summary>
+    /// Screenshot filename strategy that adds a unique counter to the prefix.
+    /// </summary>
+    public class TwoTieredCounterStrategy : AbstractPrefixAndUniqueIDStrategy
+    {
+        private static readonly Dictionary<string, int> s_prefixCounters = new Dictionary<string, int>();
+        private readonly int _uniqueNumberOfPrefix;
+        private int _count;
+
+        [InitializeOnLaunchAutopilot]
+        internal static void ResetPrefixCounters()
+        {
+            s_prefixCounters.Clear();
+        }
+
+        /// <inheritdoc/>
+        public TwoTieredCounterStrategy(string filenamePrefix = null, [CallerMemberName] string callerMemberName = null)
+            : base(filenamePrefix, callerMemberName)
+        {
+            var key = base.GetFilenamePrefix();
+            if (!s_prefixCounters.TryAdd(key, 1))
+            {
+                s_prefixCounters[key]++;
+            }
+
+            _uniqueNumberOfPrefix = s_prefixCounters[key];
+            _count = 0;
+        }
+
+        /// <inheritdoc/>
+        protected override string GetFilenamePrefix()
+        {
+            return $"{base.GetFilenamePrefix()}{_uniqueNumberOfPrefix:D2}";
+        }
+
+        /// <inheritdoc/>
+        protected override string GetUniqueID()
+        {
+            return $"{++_count:D4}";
+        }
+    }
+}

--- a/Runtime/Strategies/TwoTieredCounterStrategy.cs
+++ b/Runtime/Strategies/TwoTieredCounterStrategy.cs
@@ -2,6 +2,7 @@
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using DeNA.Anjin.Attributes;
 using TestHelper.Monkey.ScreenshotFilenameStrategies;
@@ -24,13 +25,18 @@ namespace DeNA.Anjin.Strategies
         }
 
         /// <inheritdoc/>
+        [SuppressMessage("ReSharper", "CanSimplifyDictionaryLookupWithTryAdd")]
         public TwoTieredCounterStrategy(string filenamePrefix = null, [CallerMemberName] string callerMemberName = null)
             : base(filenamePrefix, callerMemberName)
         {
             var key = base.GetFilenamePrefix();
-            if (!s_prefixCounters.TryAdd(key, 1))
+            if (s_prefixCounters.ContainsKey(key))
             {
                 s_prefixCounters[key]++;
+            }
+            else
+            {
+                s_prefixCounters[key] = 1;
             }
 
             _uniqueNumberOfPrefix = s_prefixCounters[key];

--- a/Runtime/Strategies/TwoTieredCounterStrategy.cs.meta
+++ b/Runtime/Strategies/TwoTieredCounterStrategy.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a72ee8f079554d63b06359e8b58fd204
+timeCreated: 1729492291

--- a/Tests/Runtime/Agents/UGUIMonkeyAgentTest.cs
+++ b/Tests/Runtime/Agents/UGUIMonkeyAgentTest.cs
@@ -84,7 +84,7 @@ namespace DeNA.Anjin.Agents
         public async Task Run_DefaultScreenshotFilenamePrefix_UseAgentName()
         {
             const string AgentName = "MyMonkeyAgent";
-            var filename = $"{AgentName}_0001.png";
+            var filename = $"{AgentName}01_0001.png";
             var path = Path.Combine(_defaultOutputDirectory, filename);
             if (File.Exists(path))
             {

--- a/Tests/Runtime/DeNA.Anjin.Tests.asmdef
+++ b/Tests/Runtime/DeNA.Anjin.Tests.asmdef
@@ -9,7 +9,8 @@
         "UniTask",
         "DeNA.Anjin.Editor",
         "TestHelper",
-        "TestHelper.RuntimeInternals"
+        "TestHelper.RuntimeInternals",
+        "TestHelper.Monkey"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Tests/Runtime/LauncherTest.cs
+++ b/Tests/Runtime/LauncherTest.cs
@@ -94,7 +94,7 @@ namespace DeNA.Anjin
         }
 
         [Test]
-        public async Task Launch_InitializeOnLaunchAutopilotAttributeAttachToAsyncMethod_Called()
+        public async Task Launch_InitializeOnLaunchAutopilotAttributeAttachToNonPublicMethod_Called()
         {
             SpyInitializeOnLaunchAutopilot.Reset();
 
@@ -103,7 +103,20 @@ namespace DeNA.Anjin
             settings.lifespanSec = 1;
             await LauncherFromTest.AutopilotAsync(settings); // TODO: Renamed in another PR
 
-            Assert.That(SpyInitializeOnLaunchAutopilot.IsCallInitializeOnLaunchAutopilotMethodAsync, Is.True);
+            Assert.That(SpyInitializeOnLaunchAutopilot.IsCallInitializeOnLaunchAutopilotMethodNonPublic, Is.True);
+        }
+
+        [Test]
+        public async Task Launch_InitializeOnLaunchAutopilotAttributeAttachToTaskAsyncMethod_Called()
+        {
+            SpyInitializeOnLaunchAutopilot.Reset();
+
+            var settings = ScriptableObject.CreateInstance(typeof(AutopilotSettings)) as AutopilotSettings;
+            settings.sceneAgentMaps = new List<SceneAgentMap>();
+            settings.lifespanSec = 1;
+            await LauncherFromTest.AutopilotAsync(settings); // TODO: Renamed in another PR
+
+            Assert.That(SpyInitializeOnLaunchAutopilot.IsCallInitializeOnLaunchAutopilotMethodTaskAsync, Is.True);
         }
 
         [Test]

--- a/Tests/Runtime/Strategies.meta
+++ b/Tests/Runtime/Strategies.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 68efaac534fc4f519b699b2379d6202d
+timeCreated: 1729494496

--- a/Tests/Runtime/Strategies/TwoTieredCounterStrategyTest.cs
+++ b/Tests/Runtime/Strategies/TwoTieredCounterStrategyTest.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2023-2024 DeNA Co., Ltd.
+// This software is released under the MIT License.
+
+using NUnit.Framework;
+
+namespace DeNA.Anjin.Strategies
+{
+    public class TwoTieredCounterStrategyTest
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            TwoTieredCounterStrategy.ResetPrefixCounters();
+        }
+
+        [Test]
+        public void GetFilename_WithPrefix_ReturnsUniqueFilename()
+        {
+            var sut = new TwoTieredCounterStrategy("MyPrefix");
+
+            Assert.That(sut.GetFilename(), Is.EqualTo("MyPrefix01_0001.png"));
+            Assert.That(sut.GetFilename(), Is.EqualTo("MyPrefix01_0002.png"));
+        }
+
+        [Test]
+        public void GetFilename_WithoutPrefix_ReturnsFilenameUsingTestName()
+        {
+            var sut = new TwoTieredCounterStrategy();
+
+            Assert.That(sut.GetFilename(), Is.EqualTo($"{TestContext.CurrentContext.Test.Name}01_0001.png"));
+            Assert.That(sut.GetFilename(), Is.EqualTo($"{TestContext.CurrentContext.Test.Name}01_0002.png"));
+        }
+
+        [Test]
+        public void GetFilename_WithSamePrefix_ReturnsFilenameUsingUniqueNumberByPrefix()
+        {
+            var sut = new TwoTieredCounterStrategy("MyPrefix");
+            var sut2 = new TwoTieredCounterStrategy("MyPrefix");
+
+            Assert.That(sut.GetFilename(), Is.EqualTo("MyPrefix01_0001.png"));
+            Assert.That(sut.GetFilename(), Is.EqualTo("MyPrefix01_0002.png"));
+            Assert.That(sut2.GetFilename(), Is.EqualTo("MyPrefix02_0001.png"));
+            Assert.That(sut2.GetFilename(), Is.EqualTo("MyPrefix02_0002.png"));
+        }
+
+        [Test]
+        public void GetFilename_WithAnotherPrefix_ReturnsUniqueFilenameByPrefix()
+        {
+            var sut = new TwoTieredCounterStrategy("MyPrefix");
+            var sut2 = new TwoTieredCounterStrategy("AnotherPrefix");
+
+            Assert.That(sut.GetFilename(), Is.EqualTo("MyPrefix01_0001.png"));
+            Assert.That(sut.GetFilename(), Is.EqualTo("MyPrefix01_0002.png"));
+            Assert.That(sut2.GetFilename(), Is.EqualTo("AnotherPrefix01_0001.png"));
+            Assert.That(sut2.GetFilename(), Is.EqualTo("AnotherPrefix01_0002.png"));
+        }
+    }
+}

--- a/Tests/Runtime/Strategies/TwoTieredCounterStrategyTest.cs.meta
+++ b/Tests/Runtime/Strategies/TwoTieredCounterStrategyTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 874b442c0f254493959ac3095d4af43d
+timeCreated: 1729494507

--- a/Tests/Runtime/TestDoubles/SpyInitializeOnLaunchAutopilot.cs
+++ b/Tests/Runtime/TestDoubles/SpyInitializeOnLaunchAutopilot.cs
@@ -10,13 +10,15 @@ namespace DeNA.Anjin.TestDoubles
     public static class SpyInitializeOnLaunchAutopilot
     {
         public static bool IsCallInitializeOnLaunchAutopilotMethod { get; private set; }
-        public static bool IsCallInitializeOnLaunchAutopilotMethodAsync { get; private set; }
+        public static bool IsCallInitializeOnLaunchAutopilotMethodNonPublic { get; private set; }
+        public static bool IsCallInitializeOnLaunchAutopilotMethodTaskAsync { get; private set; }
         public static bool IsCallInitializeOnLaunchAutopilotMethodUniTaskAsync { get; private set; }
 
         public static void Reset()
         {
             IsCallInitializeOnLaunchAutopilotMethod = false;
-            IsCallInitializeOnLaunchAutopilotMethodAsync = false;
+            IsCallInitializeOnLaunchAutopilotMethodNonPublic = false;
+            IsCallInitializeOnLaunchAutopilotMethodTaskAsync = false;
             IsCallInitializeOnLaunchAutopilotMethodUniTaskAsync = false;
         }
 
@@ -27,10 +29,16 @@ namespace DeNA.Anjin.TestDoubles
         }
 
         [InitializeOnLaunchAutopilot]
-        public static async Task InitializeOnLaunchAutopilotMethodAsync()
+        private static void InitializeOnLaunchAutopilotMethodNonPublic()
+        {
+            IsCallInitializeOnLaunchAutopilotMethodNonPublic = true;
+        }
+
+        [InitializeOnLaunchAutopilot]
+        public static async Task InitializeOnLaunchAutopilotMethodTaskAsync()
         {
             await Task.Delay(0);
-            IsCallInitializeOnLaunchAutopilotMethodAsync = true;
+            IsCallInitializeOnLaunchAutopilotMethodTaskAsync = true;
         }
 
         [InitializeOnLaunchAutopilot]


### PR DESCRIPTION
### Before

UGUIMonkeyAgent default screenshot filename is:

- MyMonkeyAgent_0001.png
- MyMonkeyAgent_0002.png
:

If the same Agent named `MyMonkeyAgent` is run again, the filename will be duplicated (the screenshot will be overwritten).


### After

UGUIMonkeyAgent default screenshot filename is:

- MyMonkeyAgent01_0001.png
- MyMonkeyAgent01_0002.png
:

If the same Agent named `MyMonkeyAgent` is run again, the filename will be unique.

- MyMonkeyAgent02_0001.png
- MyMonkeyAgent02_0002.png
:

This strategy is not needed in test-helper.monkey, so I implemented it inside Anjin.


### Priority

It's a low priority for me.


---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).