### PR TITLE
Fix description tooltip of Reporters

### DIFF
--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -394,10 +394,6 @@ msgstr "操作を記録したJSONファイル"
 msgid "JSON file recorded by AutomatedQA package"
 msgstr "Automated QAパッケージのRecorded Playbackウィンドウで記録したjsonファイルを設定します"
 
-# composite reporters
-msgid "Reporters"
-msgstr "レポータ"
-
 
 #: Editor/UI/Loggers/ 共通
 
@@ -458,8 +454,13 @@ msgid "Description"
 msgstr "説明"
 
 # description tooltip
-msgid "Description about this setting instance"
+msgid "Description about this reporter instance"
 msgstr "このReporterインスタンスの説明"
+
+
+#: Editor/UI/Reporters/CompositeReporterEditor.cs
+msgid "Reporters"
+msgstr "レポータ"
 
 
 #: Editor/UI/Reporters/SlackReporterEditor.cs

--- a/Editor/UI/Reporters/CompositeReporterEditor.cs
+++ b/Editor/UI/Reporters/CompositeReporterEditor.cs
@@ -15,7 +15,7 @@ namespace DeNA.Anjin.Editor.UI.Reporters
     public class CompositeReporterEditor : UnityEditor.Editor
     {
         private static readonly string s_description = L10n.Tr("Description");
-        private static readonly string s_descriptionTooltip = L10n.Tr("Description about this logger instance");
+        private static readonly string s_descriptionTooltip = L10n.Tr("Description about this reporter instance");
         private SerializedProperty _descriptionProp;
         private GUIContent _descriptionGUIContent;
 

--- a/Editor/UI/Reporters/SlackReporterEditor.cs
+++ b/Editor/UI/Reporters/SlackReporterEditor.cs
@@ -17,7 +17,7 @@ namespace DeNA.Anjin.Editor.UI.Reporters
         private const float SpacerPixelsUnderHeader = 4f;
         
         private static readonly string s_description = L10n.Tr("Description");
-        private static readonly string s_descriptionTooltip = L10n.Tr("Description about this logger instance");
+        private static readonly string s_descriptionTooltip = L10n.Tr("Description about this reporter instance");
         private SerializedProperty _descriptionProp;
         private GUIContent _descriptionGUIContent;
 


### PR DESCRIPTION
### Changes

- s/logger/reporter/ in the description tooltip of Reporters
- Move CompositeReporter in ja.po

refs #78


---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).