### PR TITLE
Ignore tests using AQA when run on Linux player

### DIFF
--- a/Tests/Runtime/Agents/UGUIPlaybackAgentTest.cs
+++ b/Tests/Runtime/Agents/UGUIPlaybackAgentTest.cs
@@ -18,6 +18,7 @@ using UnityEditor;
 namespace DeNA.Anjin.Agents
 {
     [TestFixture]
+    [UnityPlatform(exclude = new[] { RuntimePlatform.LinuxPlayer })] // Infinity loops inside the Automated QA package.
     [PrebuildSetup(typeof(CopyAssetsToResources))]
     [PostBuildCleanup(typeof(CleanupResources))]
     public class UGUIPlaybackAgentTest


### PR DESCRIPTION
### Problem

Infinite loops happen in tests using the Automated QA package when run on Linux player.

### Solution

Ignore tests using AQA on Linux player.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).