### PR TITLE
Add callback-order parameter into InitializeOnLaunchAutopilotAttribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,8 +518,12 @@ private static async UniTask InitializeOnLaunchAutopilotMethodAsync()
 }
 ```
 
-Note that the autopilot launch process is performed with `RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)` (default for `RuntimeInitializeOnLoadMethod`).
-Also, `RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)` implements the initialization process for Configurable Enter Play Mode.
+> [!NOTE]  
+> You can specify callback order with argument. Callbacks with lower values are called before ones with higher values.
+
+> [!NOTE]  
+> The autopilot launch process is performed with `RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)` (default for `RuntimeInitializeOnLoadMethod`).
+> Also, `RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)` implements the initialization process for Configurable Enter Play Mode.
 
 
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -523,8 +523,12 @@ private static async UniTask InitializeOnLaunchAutopilotMethodAsync()
 }
 ```
 
-なお、オートパイロットの起動処理は、`RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)`（`RuntimeInitializeOnLoadMethod`のデフォルト）で実行しています。
-また`RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)`で、Configurable Enter Play Modeのための初期化処理を実装しています。
+> [!NOTE]  
+> 引数に呼び出し順序を指定できます。値の低いメソッドから順に呼び出されます。
+
+> [!NOTE]  
+> オートパイロットの起動処理は、`RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)`（`RuntimeInitializeOnLoadMethod`のデフォルト）で実行しています。
+> また`RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)`で、Configurable Enter Play Modeのための初期化処理を実装しています。
 
 
 

--- a/Runtime/Agents/OneTimeAgent.cs
+++ b/Runtime/Agents/OneTimeAgent.cs
@@ -5,9 +5,6 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using DeNA.Anjin.Attributes;
 using UnityEngine;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 
 namespace DeNA.Anjin.Agents
 {
@@ -23,7 +20,7 @@ namespace DeNA.Anjin.Agents
         /// </summary>
         public AbstractAgent agent;
 
-        [SerializeField] [HideInInspector] internal bool wasExecuted;
+        public bool WasExecuted { get; internal set; }
 
         [InitializeOnLaunchAutopilot]
         public static void ResetExecutedFlag()
@@ -32,28 +29,20 @@ namespace DeNA.Anjin.Agents
             var oneTimeAgents = FindObjectsOfType<OneTimeAgent>();
             foreach (var current in oneTimeAgents)
             {
-                current.wasExecuted = false;
+                current.WasExecuted = false;
             }
-#if UNITY_EDITOR
-            // Reset asset files (in Editor only)
-            foreach (var guid in AssetDatabase.FindAssets("t:OneTimeAgent"))
-            {
-                var so = AssetDatabase.LoadAssetAtPath<OneTimeAgent>(AssetDatabase.GUIDToAssetPath(guid));
-                so.wasExecuted = false;
-            }
-#endif
         }
 
         /// <inheritdoc />
         public override async UniTask Run(CancellationToken token)
         {
-            if (wasExecuted)
+            if (WasExecuted)
             {
                 Logger.Log($"Skip {this.name} since it has already been executed");
                 return;
             }
 
-            wasExecuted = true;
+            WasExecuted = true;
 
             Logger.Log($"Enter {this.name}.Run()");
 

--- a/Runtime/Attributes/InitializeOnLaunchAutopilotAttribute.cs
+++ b/Runtime/Attributes/InitializeOnLaunchAutopilotAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 DeNA Co., Ltd.
+﻿// Copyright (c) 2023-2024 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
 using System;
@@ -8,10 +8,28 @@ namespace DeNA.Anjin.Attributes
 {
     /// <summary>
     /// Attach to a static method that performs game title-specific initialization at autopilot startup.
-    /// Initialization is performed at the timing of `RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)`.
+    /// Called when `RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)`.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class InitializeOnLaunchAutopilotAttribute : PreserveAttribute
     {
+        internal const int InitializeLoggerOrder = -20000;
+        internal const int CovertObsoleteOrder = -10000;
+        internal const int DefaultOrder = 0;
+
+        /// <summary>
+        /// Relative callback order for callbacks. Callbacks with lower values are called before ones with higher values.
+        /// </summary>
+        public int CallbackOrder { get; private set; }
+
+        /// <summary>
+        /// Attach to a static method that performs game title-specific initialization at autopilot startup.
+        /// Called when `RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)`.
+        /// </summary>
+        /// <param name="callbackOrder">Relative callback order. Callbacks with lower values are called before ones with higher values.</param>
+        public InitializeOnLaunchAutopilotAttribute(int callbackOrder = DefaultOrder)
+        {
+            this.CallbackOrder = callbackOrder;
+        }
     }
 }

--- a/Runtime/ExitCode.cs
+++ b/Runtime/ExitCode.cs
@@ -4,23 +4,28 @@
 namespace DeNA.Anjin
 {
     /// <summary>
-    /// Exit code for autopilot running
+    /// Autopilot exit code.
     /// </summary>
     public enum ExitCode
     {
         /// <summary>
-        /// Normally exit
+        /// Normally exit.
         /// </summary>
         Normally = 0,
 
         /// <summary>
-        /// Exit by un catch Exceptions
+        /// Uncaught exceptions.
         /// </summary>
         UnCatchExceptions = 1,
 
         /// <summary>
-        /// Exit by fault in log message
+        /// Autopilot running failed.
         /// </summary>
-        AutopilotFailed = 2
+        AutopilotFailed = 2,
+
+        /// <summary>
+        /// Autopilot launching failed.
+        /// </summary>
+        AutopilotLaunchingFailed
     }
 }

--- a/Runtime/Launcher.cs
+++ b/Runtime/Launcher.cs
@@ -67,6 +67,8 @@ namespace DeNA.Anjin
 #else
             var settings = Resources.Load<AutopilotSettings>(settingsPath);
 #endif
+            Assert.IsNotNull(settings, $"Autopilot settings not found: {settingsPath}");
+
             await LaunchAutopilotAsync(settings, token);
         }
 

--- a/Runtime/Launcher.cs
+++ b/Runtime/Launcher.cs
@@ -194,6 +194,12 @@ namespace DeNA.Anjin
 
         private static IEnumerable<(int, MethodInfo)> GetInitializeOnLaunchAutopilotMethods()
         {
+#if UNITY_EDITOR && UNITY_2021_3_OR_NEWER
+            return TypeCache.GetMethodsWithAttribute<InitializeOnLaunchAutopilotAttribute>()
+                .Select(x => (x.GetCustomAttribute<InitializeOnLaunchAutopilotAttribute>().CallbackOrder, x))
+                .OrderBy(x => x.Item1)
+                .Select(x => (x.Item1, x.Item2));
+#else
             const BindingFlags MethodBindingFlags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
             foreach (var method in AppDomain.CurrentDomain.GetAssemblies()
                          .SelectMany(x => x.GetTypes())
@@ -206,6 +212,7 @@ namespace DeNA.Anjin
                     yield return (attribute.CallbackOrder, method);
                 }
             }
+#endif
         }
 
         internal static async UniTask TeardownLaunchAutopilotAsync(AutopilotState state, ILogger logger,

--- a/Runtime/Launcher.cs
+++ b/Runtime/Launcher.cs
@@ -141,12 +141,12 @@ namespace DeNA.Anjin
             var tasks = new List<Task>();
             var uniTasks = new List<UniTask>();
 
-            foreach (var (_, methods) in orderedMethodMap.OrderBy(x => x.Key))
+            foreach (var order in orderedMethodMap.Keys.OrderBy(x => x))
             {
                 tasks.Clear();
                 uniTasks.Clear();
 
-                foreach (var method in methods)
+                foreach (var method in orderedMethodMap[order])
                 {
                     try
                     {

--- a/Runtime/Loggers/ConsoleLoggerAsset.cs
+++ b/Runtime/Loggers/ConsoleLoggerAsset.cs
@@ -44,7 +44,7 @@ namespace DeNA.Anjin.Loggers
             // Nothing to dispose.
         }
 
-        [InitializeOnLaunchAutopilot]
+        [InitializeOnLaunchAutopilot(InitializeOnLaunchAutopilotAttribute.InitializeLoggerOrder)]
         public static void ResetLoggers()
         {
             // Reset runtime instances

--- a/Runtime/Loggers/ConsoleLoggerAsset.cs
+++ b/Runtime/Loggers/ConsoleLoggerAsset.cs
@@ -3,9 +3,6 @@
 
 using DeNA.Anjin.Attributes;
 using UnityEngine;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 
 namespace DeNA.Anjin.Loggers
 {
@@ -53,14 +50,6 @@ namespace DeNA.Anjin.Loggers
             {
                 current._logger = null;
             }
-#if UNITY_EDITOR
-            // Reset asset files (in Editor only)
-            foreach (var guid in AssetDatabase.FindAssets($"t:{nameof(ConsoleLoggerAsset)}"))
-            {
-                var so = AssetDatabase.LoadAssetAtPath<ConsoleLoggerAsset>(AssetDatabase.GUIDToAssetPath(guid));
-                so._logger = null;
-            }
-#endif
         }
     }
 }

--- a/Runtime/Loggers/FileLoggerAsset.cs
+++ b/Runtime/Loggers/FileLoggerAsset.cs
@@ -159,7 +159,7 @@ namespace DeNA.Anjin.Loggers
             }
         }
 
-        [InitializeOnLaunchAutopilot]
+        [InitializeOnLaunchAutopilot(InitializeOnLaunchAutopilotAttribute.InitializeLoggerOrder)]
         public static void ResetLoggers()
         {
             // Reset runtime instances

--- a/Runtime/Loggers/FileLoggerAsset.cs
+++ b/Runtime/Loggers/FileLoggerAsset.cs
@@ -8,9 +8,6 @@ using DeNA.Anjin.Settings;
 using DeNA.Anjin.Utilities;
 using UnityEngine;
 using Object = UnityEngine.Object;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 
 namespace DeNA.Anjin.Loggers
 {
@@ -170,16 +167,6 @@ namespace DeNA.Anjin.Loggers
                 current._handler = null;
                 current._logger = null;
             }
-#if UNITY_EDITOR
-            // Reset asset files (in Editor only)
-            foreach (var guid in AssetDatabase.FindAssets($"t:{nameof(FileLoggerAsset)}"))
-            {
-                var so = AssetDatabase.LoadAssetAtPath<FileLoggerAsset>(AssetDatabase.GUIDToAssetPath(guid));
-                so._handler?.Dispose();
-                so._handler = null;
-                so._logger = null;
-            }
-#endif
         }
     }
 }

--- a/Tests/Runtime/Agents/OneTimeAgentTest.cs
+++ b/Tests/Runtime/Agents/OneTimeAgentTest.cs
@@ -70,7 +70,7 @@ namespace DeNA.Anjin.Agents
                 await UniTask.Delay(500); // Consider overhead
 
                 Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Succeeded));
-                Assert.That(agent.wasExecuted, Is.True);
+                Assert.That(agent.WasExecuted, Is.True);
             }
 
             LogAssert.Expect(LogType.Log, $"Enter {agent.name}.Run()");
@@ -87,7 +87,7 @@ namespace DeNA.Anjin.Agents
             agent.Random = new RandomFactory(0).CreateRandom();
             agent.name = nameof(Run_cancelTask_stopAgent);
             agent.agent = childAgent;
-            agent.wasExecuted = true;
+            agent.WasExecuted = true;
 
             using (var cancellationTokenSource = new CancellationTokenSource())
             {
@@ -132,14 +132,14 @@ namespace DeNA.Anjin.Agents
         public async Task ResetExecutedFlagWhenLaunchAutopilot()
         {
             var sut = ScriptableObject.CreateInstance<OneTimeAgent>();
-            sut.wasExecuted = true;
+            sut.WasExecuted = true;
 
             var settings = ScriptableObject.CreateInstance<AutopilotSettings>();
             settings.lifespanSec = 1;
             await Launcher.LaunchAutopilotAsync(settings);
 
             sut = ScriptableObject.CreateInstance<OneTimeAgent>(); // Reload because domain reloaded
-            Assert.That(sut.wasExecuted, Is.False); // was reset
+            Assert.That(sut.WasExecuted, Is.False); // was reset
         }
     }
 }

--- a/Tests/Runtime/LauncherTest.cs
+++ b/Tests/Runtime/LauncherTest.cs
@@ -76,7 +76,7 @@ namespace DeNA.Anjin
         }
 
         [Test]
-        public async Task LaunchAutopilotAsync_InitializeOnLaunchAutopilotAttribute_Called()
+        public async Task LaunchAutopilotAsync_InitializeOnLaunchAutopilotMethodWasCalled()
         {
             SpyInitializeOnLaunchAutopilot.Reset();
 
@@ -86,11 +86,11 @@ namespace DeNA.Anjin
             settings.lifespanSec = 1;
             await Launcher.LaunchAutopilotAsync(settings);
 
-            Assert.That(SpyInitializeOnLaunchAutopilot.IsCallInitializeOnLaunchAutopilotMethod, Is.True);
+            Assert.That(SpyInitializeOnLaunchAutopilot.WasCalled, Is.True);
         }
 
         [Test]
-        public async Task LaunchAutopilotAsync_InitializeOnLaunchAutopilotAttributeAttachToNonPublicMethod_Called()
+        public async Task LaunchAutopilotAsync_InitializeOnLaunchAutopilotNonPublicMethodWasCalled()
         {
             SpyInitializeOnLaunchAutopilot.Reset();
 
@@ -99,25 +99,11 @@ namespace DeNA.Anjin
             settings.lifespanSec = 1;
             await Launcher.LaunchAutopilotAsync(settings);
 
-            Assert.That(SpyInitializeOnLaunchAutopilot.IsCallInitializeOnLaunchAutopilotMethodNonPublic, Is.True);
+            Assert.That(SpyInitializeOnLaunchAutopilot.WasCalledNonPublicMethod, Is.True);
         }
 
         [Test]
-        public async Task LaunchAutopilotAsync_InitializeOnLaunchAutopilotAttributeAttachToTaskAsyncMethod_Called()
-        {
-            SpyInitializeOnLaunchAutopilot.Reset();
-
-            var settings = ScriptableObject.CreateInstance(typeof(AutopilotSettings)) as AutopilotSettings;
-            Assume.That(settings, Is.Not.Null);
-            settings.sceneAgentMaps = new List<SceneAgentMap>();
-            settings.lifespanSec = 1;
-            await Launcher.LaunchAutopilotAsync(settings);
-
-            Assert.That(SpyInitializeOnLaunchAutopilot.IsCallInitializeOnLaunchAutopilotMethodTaskAsync, Is.True);
-        }
-
-        [Test]
-        public async Task LaunchAutopilotAsync_InitializeOnLaunchAutopilotAttributeAttachToUniTaskAsyncMethod_Called()
+        public async Task LaunchAutopilotAsync_InitializeOnLaunchAutopilotTaskAsyncWasCalled()
         {
             SpyInitializeOnLaunchAutopilot.Reset();
 
@@ -127,7 +113,21 @@ namespace DeNA.Anjin
             settings.lifespanSec = 1;
             await Launcher.LaunchAutopilotAsync(settings);
 
-            Assert.That(SpyInitializeOnLaunchAutopilot.IsCallInitializeOnLaunchAutopilotMethodUniTaskAsync, Is.True);
+            Assert.That(SpyInitializeOnLaunchAutopilot.WasCalledTaskAsync, Is.True);
+        }
+
+        [Test]
+        public async Task LaunchAutopilotAsync_InitializeOnLaunchAutopilotUniTaskAsyncWasCalled()
+        {
+            SpyInitializeOnLaunchAutopilot.Reset();
+
+            var settings = ScriptableObject.CreateInstance(typeof(AutopilotSettings)) as AutopilotSettings;
+            Assume.That(settings, Is.Not.Null);
+            settings.sceneAgentMaps = new List<SceneAgentMap>();
+            settings.lifespanSec = 1;
+            await Launcher.LaunchAutopilotAsync(settings);
+
+            Assert.That(SpyInitializeOnLaunchAutopilot.WasCalledUniTaskAsync, Is.True);
         }
     }
 }

--- a/Tests/Runtime/Loggers/ConsoleLoggerAssetTest.cs
+++ b/Tests/Runtime/Loggers/ConsoleLoggerAssetTest.cs
@@ -42,7 +42,7 @@ namespace DeNA.Anjin.Loggers
         }
 
         [Test]
-        public void ResetLoggers_InstanceOnly_ResetLoggerAsset()
+        public void ResetLoggers_ResetLoggerAsset()
         {
             var sut = ScriptableObject.CreateInstance<ConsoleLoggerAsset>();
             sut.filterLogType = LogType.Warning;
@@ -56,26 +56,6 @@ namespace DeNA.Anjin.Loggers
             sut.Logger.Log("After reset");
             sut.Dispose();
             Assert.That(sut.Logger.filterLogType, Is.EqualTo(LogType.Error));
-        }
-
-        [Test]
-        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
-        public void ResetLoggers_FromAssetFile_ResetLoggerAsset()
-        {
-#if UNITY_EDITOR
-            var sut = AssetDatabase.LoadAssetAtPath<ConsoleLoggerAsset>(
-                "Packages/com.dena.anjin/Tests/TestAssets/ConsoleLogger.asset");
-            sut.Logger.Log("Before reset");
-            sut.Dispose();
-            Assume.That(sut.Logger.filterLogType, Is.EqualTo(LogType.Warning));
-
-            ConsoleLoggerAsset.ResetLoggers(); // Called when on launch autopilot
-
-            sut.filterLogType = LogType.Error;
-            sut.Logger.Log("After reset");
-            sut.Dispose();
-            Assert.That(sut.Logger.filterLogType, Is.EqualTo(LogType.Error));
-#endif
         }
     }
 }

--- a/Tests/Runtime/Loggers/FileLoggerAssetTest.cs
+++ b/Tests/Runtime/Loggers/FileLoggerAssetTest.cs
@@ -244,7 +244,7 @@ namespace DeNA.Anjin.Loggers
         }
 
         [Test]
-        public async Task ResetLoggers_InstanceOnly_ResetLoggerAsset()
+        public async Task ResetLoggers_ResetLoggerAsset()
         {
             var path = GetOutputPath();
             var sut = ScriptableObject.CreateInstance<FileLoggerAsset>();
@@ -261,30 +261,6 @@ namespace DeNA.Anjin.Loggers
             sut.Dispose();
             await Task.Yield();
             Assert.That(path, Does.Exist);
-        }
-
-        [Test]
-        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
-        public async Task ResetLoggers_FromAssetFile_ResetLoggerAsset()
-        {
-            var path = GetOutputPath();
-#if UNITY_EDITOR
-            var sut = AssetDatabase.LoadAssetAtPath<FileLoggerAsset>(
-                "Packages/com.dena.anjin/Tests/TestAssets/FileLogger.asset");
-            sut.outputPath = path;
-            sut.Logger.Log("Before reset");
-            sut.Dispose();
-            await Task.Yield();
-            Assume.That(path, Does.Exist);
-
-            File.Delete(path);
-            FileLoggerAsset.ResetLoggers(); // Called when on launch autopilot
-
-            sut.Logger.Log("After reset");
-            sut.Dispose();
-            await Task.Yield();
-            Assert.That(path, Does.Exist);
-#endif
         }
     }
 }

--- a/Tests/Runtime/TestDoubles/SpyInitializeOnLaunchAutopilot.cs
+++ b/Tests/Runtime/TestDoubles/SpyInitializeOnLaunchAutopilot.cs
@@ -9,43 +9,43 @@ namespace DeNA.Anjin.TestDoubles
 {
     public static class SpyInitializeOnLaunchAutopilot
     {
-        public static bool IsCallInitializeOnLaunchAutopilotMethod { get; private set; }
-        public static bool IsCallInitializeOnLaunchAutopilotMethodNonPublic { get; private set; }
-        public static bool IsCallInitializeOnLaunchAutopilotMethodTaskAsync { get; private set; }
-        public static bool IsCallInitializeOnLaunchAutopilotMethodUniTaskAsync { get; private set; }
+        public static bool WasCalled { get; private set; }
+        public static bool WasCalledNonPublicMethod { get; private set; }
+        public static bool WasCalledTaskAsync { get; private set; }
+        public static bool WasCalledUniTaskAsync { get; private set; }
 
         public static void Reset()
         {
-            IsCallInitializeOnLaunchAutopilotMethod = false;
-            IsCallInitializeOnLaunchAutopilotMethodNonPublic = false;
-            IsCallInitializeOnLaunchAutopilotMethodTaskAsync = false;
-            IsCallInitializeOnLaunchAutopilotMethodUniTaskAsync = false;
+            WasCalled = false;
+            WasCalledNonPublicMethod = false;
+            WasCalledTaskAsync = false;
+            WasCalledUniTaskAsync = false;
         }
 
         [InitializeOnLaunchAutopilot]
         public static void InitializeOnLaunchAutopilotMethod()
         {
-            IsCallInitializeOnLaunchAutopilotMethod = true;
+            WasCalled = true;
         }
 
         [InitializeOnLaunchAutopilot]
-        private static void InitializeOnLaunchAutopilotMethodNonPublic()
+        private static void InitializeOnLaunchAutopilotNonPublicMethod()
         {
-            IsCallInitializeOnLaunchAutopilotMethodNonPublic = true;
+            WasCalledNonPublicMethod = true;
         }
 
         [InitializeOnLaunchAutopilot]
-        public static async Task InitializeOnLaunchAutopilotMethodTaskAsync()
+        public static async Task InitializeOnLaunchAutopilotTaskAsync()
         {
             await Task.Delay(0);
-            IsCallInitializeOnLaunchAutopilotMethodTaskAsync = true;
+            WasCalledTaskAsync = true;
         }
 
         [InitializeOnLaunchAutopilot]
-        public static async UniTask InitializeOnLaunchAutopilotMethodUniTaskAsync()
+        public static async UniTask InitializeOnLaunchAutopilotUniTaskAsync()
         {
             await UniTask.Delay(0);
-            IsCallInitializeOnLaunchAutopilotMethodUniTaskAsync = true;
+            WasCalledUniTaskAsync = true;
         }
     }
 }


### PR DESCRIPTION
### Changes

- Add callback-order parameter into InitializeOnLaunchAutopilotAttribute
    - Call initialize methods by ordered
    - Using TypeCache when Unity 2021.3 or newer
    - Logger's initialization is earliest
- Fix to remove unnecessary field reset
    - Non-public field and property is not serialized in OneTimeAgent, ConsoleLogger, and FileLogger
- Fix to cancel launching autopilot when initialize failed

### Priority

I hope to review && merge in this week.
There is no need to release it yet.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).