### PR TITLE
Post a report when normally termination

### DIFF
--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -501,10 +501,26 @@ msgstr "@hereをメッセージにつける"
 msgid "Whether adding @here into Slack messages or not"
 msgstr "Slack通知メッセージに@hereを付けます"
 
-# withScreenshot
+# withScreenshotOnError
 msgid "Take screenshot"
 msgstr "スクリーンショット"
 
-# withScreenshot tooltip
-msgid "Take screenshot when posting report"
-msgstr "スクリーンショットを撮影してレポートに含めます"
+# withScreenshotOnError tooltip
+msgid "Take a screenshot when posting an error terminated report"
+msgstr "エラー終了時にスクリーンショットを撮影します"
+
+# postOnNormally
+msgid "Normally terminated report"
+msgstr "正常終了時にもレポート"
+
+# postOnNormally tooltip
+msgid "Post a report if normally terminates."
+msgstr "正常終了時にもレポートをポストします"
+
+# withScreenshotOnNormally (same as withScreenshotOnError)
+msgid "Take screenshot"
+msgstr "スクリーンショット"
+
+# withScreenshotOnNormally tooltip
+msgid "Take a screenshot when posting a normally terminated report"
+msgstr "正常終了時にスクリーンショットを撮影します"

--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -500,3 +500,11 @@ msgstr "@hereをメッセージにつける"
 # addHereInSlackMessage tooltip
 msgid "Whether adding @here into Slack messages or not"
 msgstr "Slack通知メッセージに@hereを付けます"
+
+# withScreenshot
+msgid "Take screenshot"
+msgstr "スクリーンショット"
+
+# withScreenshot tooltip
+msgid "Take screenshot when posting report"
+msgstr "スクリーンショットを撮影してレポートに含めます"

--- a/Editor/UI/Reporters/SlackReporterEditor.cs
+++ b/Editor/UI/Reporters/SlackReporterEditor.cs
@@ -14,7 +14,6 @@ namespace DeNA.Anjin.Editor.UI.Reporters
     public class SlackReporterEditor : UnityEditor.Editor
     {
         private const float SpacerPixels = 10f;
-        private const float SpacerPixelsUnderHeader = 4f;
 
         private static readonly string s_description = L10n.Tr("Description");
         private static readonly string s_descriptionTooltip = L10n.Tr("Description about this Reporter instance");
@@ -31,8 +30,6 @@ namespace DeNA.Anjin.Editor.UI.Reporters
         private SerializedProperty _slackChannelsProp;
         private GUIContent _slackChannelsGUIContent;
 
-        private static readonly string s_slackMentionSettingsHeader = L10n.Tr("Slack Mention Settings");
-
         private static readonly string s_mentionSubTeamIDs = L10n.Tr("Sub Team IDs to Mention");
         private static readonly string s_mentionSubTeamIDsTooltip = L10n.Tr("Sub team IDs to mention (comma separates)");
         private SerializedProperty _mentionSubTeamIDsProp;
@@ -43,11 +40,20 @@ namespace DeNA.Anjin.Editor.UI.Reporters
         private SerializedProperty _addHereInSlackMessageProp;
         private GUIContent _addHereInSlackMessageGUIContent;
 
-        private static readonly string s_withScreenshot = L10n.Tr("Take screenshot");
-        private static readonly string s_withScreenshotTooltip = L10n.Tr("Take screenshot when posting report");
-        private SerializedProperty _withScreenshotProp;
-        private GUIContent _withScreenshotGUIContent;
+        private static readonly string s_withScreenshotOnError = L10n.Tr("Take screenshot");
+        private static readonly string s_withScreenshotOnErrorTooltip = L10n.Tr("Take a screenshot when posting an error terminated report");
+        private SerializedProperty _withScreenshotOnErrorProp;
+        private GUIContent _withScreenshotOnErrorGUIContent;
 
+        private static readonly string s_postOnNormally = L10n.Tr("Normally terminated report");
+        private static readonly string s_postOnNormallyTooltip = L10n.Tr("Post a report if normally terminates.");
+        private SerializedProperty _postOnNormallyProp;
+        private GUIContent _postOnNormallyGUIContent;
+
+        private static readonly string s_withScreenshotOnNormally = L10n.Tr("Take screenshot");
+        private static readonly string s_withScreenshotOnNormallyTooltip = L10n.Tr("Take a screenshot when posting a normally terminated report");
+        private SerializedProperty _withScreenshotOnNormallyProp;
+        private GUIContent _withScreenshotOnNormallyGUIContent;
 
         private void OnEnable()
         {
@@ -72,8 +78,14 @@ namespace DeNA.Anjin.Editor.UI.Reporters
             _addHereInSlackMessageProp = serializedObject.FindProperty(nameof(SlackReporter.addHereInSlackMessage));
             _addHereInSlackMessageGUIContent = new GUIContent(s_addHereInSlackMessage, s_addHereInSlackMessageTooltip);
 
-            _withScreenshotProp = serializedObject.FindProperty(nameof(SlackReporter.withScreenshot));
-            _withScreenshotGUIContent = new GUIContent(s_withScreenshot, s_withScreenshotTooltip);
+            _withScreenshotOnErrorProp = serializedObject.FindProperty(nameof(SlackReporter.withScreenshotOnError));
+            _withScreenshotOnErrorGUIContent = new GUIContent(s_withScreenshotOnError, s_withScreenshotOnErrorTooltip);
+
+            _postOnNormallyProp = serializedObject.FindProperty(nameof(SlackReporter.postOnNormally));
+            _postOnNormallyGUIContent = new GUIContent(s_postOnNormally, s_postOnNormallyTooltip);
+
+            _withScreenshotOnNormallyProp = serializedObject.FindProperty(nameof(SlackReporter.withScreenshotOnNormally));
+            _withScreenshotOnNormallyGUIContent = new GUIContent(s_withScreenshotOnNormally, s_withScreenshotOnNormallyTooltip);
         }
 
 
@@ -88,14 +100,18 @@ namespace DeNA.Anjin.Editor.UI.Reporters
             EditorGUILayout.PropertyField(_slackChannelsProp, _slackChannelsGUIContent);
 
             GUILayout.Space(SpacerPixels);
-            GUILayout.Label(s_slackMentionSettingsHeader);
-            GUILayout.Space(SpacerPixelsUnderHeader);
-
             EditorGUILayout.PropertyField(_mentionSubTeamIDsProp, _mentionSubTeamIDsGUIContent);
             EditorGUILayout.PropertyField(_addHereInSlackMessageProp, _addHereInSlackMessageGUIContent);
 
             GUILayout.Space(SpacerPixels);
-            EditorGUILayout.PropertyField(_withScreenshotProp, _withScreenshotGUIContent);
+            EditorGUILayout.PropertyField(_withScreenshotOnErrorProp, _withScreenshotOnErrorGUIContent);
+
+            GUILayout.Space(SpacerPixels);
+            EditorGUILayout.PropertyField(_postOnNormallyProp, _postOnNormallyGUIContent);
+
+            EditorGUI.BeginDisabledGroup(!_postOnNormallyProp.boolValue);
+            EditorGUILayout.PropertyField(_withScreenshotOnNormallyProp, _withScreenshotOnNormallyGUIContent);
+            EditorGUI.EndDisabledGroup();
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Editor/UI/Reporters/SlackReporterEditor.cs
+++ b/Editor/UI/Reporters/SlackReporterEditor.cs
@@ -15,7 +15,7 @@ namespace DeNA.Anjin.Editor.UI.Reporters
     {
         private const float SpacerPixels = 10f;
         private const float SpacerPixelsUnderHeader = 4f;
-        
+
         private static readonly string s_description = L10n.Tr("Description");
         private static readonly string s_descriptionTooltip = L10n.Tr("Description about this Reporter instance");
         private SerializedProperty _descriptionProp;
@@ -43,6 +43,11 @@ namespace DeNA.Anjin.Editor.UI.Reporters
         private SerializedProperty _addHereInSlackMessageProp;
         private GUIContent _addHereInSlackMessageGUIContent;
 
+        private static readonly string s_withScreenshot = L10n.Tr("Take screenshot");
+        private static readonly string s_withScreenshotTooltip = L10n.Tr("Take screenshot when posting report");
+        private SerializedProperty _withScreenshotProp;
+        private GUIContent _withScreenshotGUIContent;
+
 
         private void OnEnable()
         {
@@ -66,13 +71,16 @@ namespace DeNA.Anjin.Editor.UI.Reporters
 
             _addHereInSlackMessageProp = serializedObject.FindProperty(nameof(SlackReporter.addHereInSlackMessage));
             _addHereInSlackMessageGUIContent = new GUIContent(s_addHereInSlackMessage, s_addHereInSlackMessageTooltip);
+
+            _withScreenshotProp = serializedObject.FindProperty(nameof(SlackReporter.withScreenshot));
+            _withScreenshotGUIContent = new GUIContent(s_withScreenshot, s_withScreenshotTooltip);
         }
 
 
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
-            
+
             EditorGUILayout.PropertyField(_descriptionProp, _descriptionGUIContent);
             GUILayout.Space(SpacerPixels);
 
@@ -82,9 +90,12 @@ namespace DeNA.Anjin.Editor.UI.Reporters
             GUILayout.Space(SpacerPixels);
             GUILayout.Label(s_slackMentionSettingsHeader);
             GUILayout.Space(SpacerPixelsUnderHeader);
-            
+
             EditorGUILayout.PropertyField(_mentionSubTeamIDsProp, _mentionSubTeamIDsGUIContent);
             EditorGUILayout.PropertyField(_addHereInSlackMessageProp, _addHereInSlackMessageGUIContent);
+
+            GUILayout.Space(SpacerPixels);
+            EditorGUILayout.PropertyField(_withScreenshotProp, _withScreenshotGUIContent);
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/Editor/UI/Settings/AutopilotSettingsEditor.cs
+++ b/Editor/UI/Settings/AutopilotSettingsEditor.cs
@@ -146,7 +146,7 @@ namespace DeNA.Anjin.Editor.UI.Settings
             var autopilot = FindObjectOfType<Autopilot>();
             if (autopilot)
             {
-                autopilot.TerminateAsync(ExitCode.Normally).Forget();
+                autopilot.TerminateAsync(ExitCode.Normally, reporting: false).Forget();
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -461,12 +461,15 @@ The instance of this Reporter (.asset file) can have the following settings.
         The bot must be invited to the channel.</dd>
   <dt>Mention Sub Team IDs</dt><dd>Comma Separated Team IDs to mention in notification message</dd>
   <dt>Add Here In Slack Message</dt><dd>Add @here to notification message. Default is off</dd>
+  <dt>Take screenshot</dt><dd>Take a screenshot when posting an error terminated report. Default is on</dd>
+  <dt>Normally terminated report</dt><dd>Post a report if normally terminates. Default is off</dd>
+  <dt>Take screenshot</dt><dd>Take a screenshot when posting a normally terminated report. Default is off</dd>
 </dl>
 
-You can create a bot on the following page:  
+You can create a Slack Bot on the following page:  
 [Slack API: Applications](https://api.slack.com/apps)
 
-The bot needs the following permissions:
+The Slack Bot needs the following permissions:
 
 - chat:write
 - files:write

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This item can also be overridden from the commandline (see below).
   <dt>Time Scale</dt><dd>Time.timeScale. Default is 1.0</dd>
   <dt>JUnit Report Path</dt><dd>Specifies the JUnit format report file output path (optional). If there are zero errors and zero failures, the autopilot run is considered to have completed successfully. </dd>
   <dt>Logger</dt><dd>Logger used for this autopilot settings. If omitted, <code>Debug.unityLogger</code> will be used as default.</dd>
-  <dt>Reporter</dt><dd>Reporter that called when some errors occurred in target application</dd>
+  <dt>Reporter</dt><dd>Reporter to be called on Autopilot terminate.</dd>
 </dl>
 
 #### Error Handling Settings

--- a/README_ja.md
+++ b/README_ja.md
@@ -119,7 +119,7 @@ v1.0.0時点では `EmergencyExitAgent` の使用を想定しています。
   <dt>Time Scale</dt><dd>Time.timeScaleを指定します。デフォルトは1.0</dd>
   <dt>JUnit Report Path</dt><dd>JUnit形式のレポートファイル出力パスを指定します（省略可）。オートパイロット実行の成否は、Unityエディターの終了コードでなくこのファイルを見て判断するのが確実です。errors, failuresともに0件であれば正常終了と判断できます。</dd>
   <dt>Logger</dt><dd>オートパイロットが使用するLogger指定します。省略時は <code>Debug.unityLogger</code> がデフォルトとして使用されます</dd>
-  <dt>Reporter</dt><dd>対象のアプリケーションで発生したエラーを通知するReporterを指定します</dd>
+  <dt>Reporter</dt><dd>オートパイロット終了時に通知を行なうReporterを指定します</dd>
 </dl>
 
 #### エラーハンドリング設定

--- a/README_ja.md
+++ b/README_ja.md
@@ -464,13 +464,16 @@ Slackにレポート送信するReporterです。
         コマンドライン引数 <code>-SLACK_CHANNELS</code> で上書きできます。
         チャンネルにはBotを招待しておく必要があります。</dd>
   <dt>Mention Sub Team IDs</dt><dd>通知メッセージでメンションするチームのIDをカンマ区切りで指定します</dd>
-  <dt>Add Here In Slack Message</dt><dd>通知メッセージに@hereを付けます。デフォルトはoff</dd>
+  <dt>Add Here In Slack Message</dt><dd>通知メッセージに@hereを付けます（デフォルト: off）</dd>
+  <dt>Take screenshot</dt><dd>エラー終了時にスクリーンショットを撮影します（デフォルト: on）</dd>
+  <dt>Normally terminated report</dt><dd>正常終了時にもレポートをポストします（デフォルト: off）</dd>
+  <dt>Take screenshot</dt><dd>正常終了時にスクリーンショットを撮影します（デフォルト: off）</dd>
 </dl>
 
-Botは次のページで作成できます。  
+Slack Botは次のページで作成できます。  
 [Slack API: Applications](https://api.slack.com/apps)
 
-Botには次の権限が必要です。
+Slack Botには次の権限が必要です。
 
 - chat:write
 - files:write

--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -16,9 +16,27 @@ using Assert = UnityEngine.Assertions.Assert;
 namespace DeNA.Anjin
 {
     /// <summary>
+    /// Can be terminated.
+    /// </summary>
+    public interface ITerminatable
+    {
+        /// <summary>
+        /// Terminate autopilot
+        /// </summary>
+        /// <param name="exitCode">Exit code for Unity Editor/ Player-build</param>
+        /// <param name="message">Log message string or terminate message</param>
+        /// <param name="stackTrace">Stack trace when terminate by the log message</param>
+        /// <param name="reporting">Call Reporter if true</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>A task awaits termination get completed</returns>
+        public UniTask TerminateAsync(ExitCode exitCode, string message = null, string stackTrace = null,
+            bool reporting = true, CancellationToken token = default);
+    }
+
+    /// <summary>
     /// Autopilot main logic
     /// </summary>
-    public class Autopilot : MonoBehaviour
+    public class Autopilot : MonoBehaviour, ITerminatable
     {
         private AbstractLoggerAsset _loggerAsset;
         private ILogger _logger;
@@ -51,7 +69,7 @@ namespace DeNA.Anjin
             // NOTE: Registering logMessageReceived must be placed before DispatchByScene.
             //       Because some agent can throw an error immediately, so reporter can miss the error if
             //       registering logMessageReceived is placed after DispatchByScene.
-            _logMessageHandler = new LogMessageHandler(_settings);
+            _logMessageHandler = new LogMessageHandler(_settings, this);
 
             _dispatcher = new AgentDispatcher(_settings, _logger, _randomFactory);
             var dispatched = _dispatcher.DispatchByScene(SceneManager.GetActiveScene(), false);
@@ -140,15 +158,7 @@ This time, temporarily generate and use SlackReporter instance.");
             _settings.loggerAsset?.Dispose();
         }
 
-        /// <summary>
-        /// Terminate autopilot
-        /// </summary>
-        /// <param name="exitCode">Exit code for Unity Editor/ Player-build</param>
-        /// <param name="message">Log message string or terminate message</param>
-        /// <param name="stackTrace">Stack trace when terminate by the log message</param>
-        /// <param name="reporting">Call Reporter if true</param>
-        /// <param name="token">Cancellation token</param>
-        /// <returns>A task awaits termination get completed</returns>
+        /// <inheritdoc/>
         public async UniTask TerminateAsync(ExitCode exitCode, string message = null, string stackTrace = null,
             bool reporting = true, CancellationToken token = default)
         {
@@ -169,12 +179,6 @@ This time, temporarily generate and use SlackReporter instance.");
             await Launcher.TeardownLaunchAutopilotAsync(_state, _logger, exitCode, "Autopilot", token);
         }
 
-        /// <summary>
-        /// Terminate autopilot
-        /// </summary>
-        /// <param name="exitCode">Exit code for Unity Editor</param>
-        /// <param name="logString">Log message string when terminate by the log message</param>
-        /// <param name="stackTrace">Stack trace when terminate by the log message</param>
         [Obsolete("Use " + nameof(TerminateAsync))]
         public void Terminate(ExitCode exitCode, string logString = null, string stackTrace = null)
         {

--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -46,6 +46,7 @@ namespace DeNA.Anjin
         private AutopilotState _state;
         private AutopilotSettings _settings;
         private float _startTime;
+        private bool _isTerminating;
 
         private void Start()
         {
@@ -153,6 +154,7 @@ This time, temporarily generate and use SlackReporter instance.");
             // Clear event listeners.
             // When play mode is stopped by the user, onDestroy calls without TerminateAsync.
 
+            _logger?.Log("Destroy Autopilot object");
             _dispatcher?.Dispose();
             _logMessageHandler?.Dispose();
             _settings.loggerAsset?.Dispose();
@@ -162,6 +164,13 @@ This time, temporarily generate and use SlackReporter instance.");
         public async UniTask TerminateAsync(ExitCode exitCode, string message = null, string stackTrace = null,
             bool reporting = true, CancellationToken token = default)
         {
+            if (_isTerminating)
+            {
+                return; // Prevent multiple termination.
+            }
+
+            _isTerminating = true;
+
             if (reporting && _state.IsRunning && _settings.reporter != null)
             {
                 await _settings.reporter.PostReportAsync(message, stackTrace, exitCode, token);

--- a/Runtime/Reporters/AbstractReporter.cs
+++ b/Runtime/Reporters/AbstractReporter.cs
@@ -8,7 +8,8 @@ using UnityEngine;
 namespace DeNA.Anjin.Reporters
 {
     /// <summary>
-    /// Reporter base class
+    /// Reporter base class.
+    /// Reporter is called on Autopilot termination.
     /// </summary>
     public abstract class AbstractReporter : ScriptableObject
     {
@@ -22,17 +23,15 @@ namespace DeNA.Anjin.Reporters
         /// <summary>
         /// Post report log message, stacktrace and screenshot
         /// </summary>
-        /// <param name="logString">Log message</param>
-        /// <param name="stackTrace">Stack trace</param>
-        /// <param name="type">Log message type</param>
-        /// <param name="withScreenshot">With screenshot</param>
+        /// <param name="message">Log message or terminate message</param>
+        /// <param name="stackTrace">Stack trace (can be null)</param>
+        /// <param name="exitCode">Exit code indicating the reason for termination</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         public abstract UniTask PostReportAsync(
-            string logString,
+            string message,
             string stackTrace,
-            LogType type,
-            bool withScreenshot,
+            ExitCode exitCode,
             CancellationToken cancellationToken = default
         );
     }

--- a/Runtime/Reporters/CompositeReporter.cs
+++ b/Runtime/Reporters/CompositeReporter.cs
@@ -23,10 +23,9 @@ namespace DeNA.Anjin.Reporters
 
         /// <inheritdoc />
         public override async UniTask PostReportAsync(
-            string logString,
+            string message,
             string stackTrace,
-            LogType type,
-            bool withScreenshot,
+            ExitCode exitCode,
             CancellationToken cancellationToken = default
         )
         {
@@ -34,7 +33,7 @@ namespace DeNA.Anjin.Reporters
                 reporters
                     .Where(r => r != this && r != null)
                     .Select(
-                        r => r.PostReportAsync(logString, stackTrace, type, withScreenshot, cancellationToken)
+                        r => r.PostReportAsync(message, stackTrace, exitCode, cancellationToken)
                     )
             );
         }

--- a/Runtime/Reporters/SlackReporter.cs
+++ b/Runtime/Reporters/SlackReporter.cs
@@ -34,14 +34,18 @@ namespace DeNA.Anjin.Reporters
         /// </summary>
         public bool addHereInSlackMessage;
 
+        /// <summary>
+        /// With screenshot or not
+        /// </summary>
+        public bool withScreenshot;
+
         private readonly ISlackMessageSender _sender = new SlackMessageSender(new SlackAPI());
 
         /// <inheritdoc />
         public override async UniTask PostReportAsync(
-            string logString,
+            string message,
             string stackTrace,
-            LogType type,
-            bool withScreenshot,
+            ExitCode exitCode,
             CancellationToken cancellationToken = default
         )
         {
@@ -60,7 +64,7 @@ namespace DeNA.Anjin.Reporters
                     slackChannel,
                     mentionSubTeamIDs.Split(','),
                     addHereInSlackMessage,
-                    logString,
+                    message,
                     stackTrace,
                     withScreenshot,
                     cancellationToken

--- a/Runtime/Utilities/LogMessageHandler.cs
+++ b/Runtime/Utilities/LogMessageHandler.cs
@@ -18,18 +18,15 @@ namespace DeNA.Anjin.Utilities
     public class LogMessageHandler : IDisposable
     {
         private readonly AutopilotSettings _settings;
-        private readonly AbstractReporter _reporter;
         private List<Regex> _ignoreMessagesRegexes;
 
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="settings">Autopilot settings</param>
-        /// <param name="reporter">Reporter implementation</param>
-        public LogMessageHandler(AutopilotSettings settings, AbstractReporter reporter = null)
+        public LogMessageHandler(AutopilotSettings settings)
         {
             _settings = settings;
-            _reporter = reporter != null ? reporter : _settings.reporter;
 
             Application.logMessageReceivedThreaded += this.HandleLog;
         }
@@ -63,11 +60,6 @@ namespace DeNA.Anjin.Utilities
             if (_settings.loggerAsset != null)
             {
                 _settings.loggerAsset.Logger.Log(type, logString, stackTrace);
-            }
-
-            if (_reporter != null)
-            {
-                await _reporter.PostReportAsync(logString, stackTrace, type, true);
             }
 
             var autopilot = Object.FindObjectOfType<Autopilot>();

--- a/Runtime/Utilities/LogMessageHandler.cs
+++ b/Runtime/Utilities/LogMessageHandler.cs
@@ -8,7 +8,6 @@ using Cysharp.Threading.Tasks;
 using DeNA.Anjin.Reporters;
 using DeNA.Anjin.Settings;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
 namespace DeNA.Anjin.Utilities
 {
@@ -18,15 +17,19 @@ namespace DeNA.Anjin.Utilities
     public class LogMessageHandler : IDisposable
     {
         private readonly AutopilotSettings _settings;
+        private readonly ITerminatable _autopilot;
+
         private List<Regex> _ignoreMessagesRegexes;
 
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="settings">Autopilot settings</param>
-        public LogMessageHandler(AutopilotSettings settings)
+        /// <param name="autopilot">Autopilot instance that termination target</param>
+        public LogMessageHandler(AutopilotSettings settings, ITerminatable autopilot)
         {
             _settings = settings;
+            _autopilot = autopilot;
 
             Application.logMessageReceivedThreaded += this.HandleLog;
         }
@@ -62,17 +65,13 @@ namespace DeNA.Anjin.Utilities
                 _settings.loggerAsset.Logger.Log(type, logString, stackTrace);
             }
 
-            var autopilot = Object.FindObjectOfType<Autopilot>();
-            if (autopilot != null)
+            if (type == LogType.Exception)
             {
-                if (type == LogType.Exception)
-                {
-                    await autopilot.TerminateAsync(ExitCode.UnCatchExceptions, logString, stackTrace);
-                }
-                else
-                {
-                    await autopilot.TerminateAsync(ExitCode.AutopilotFailed, logString, stackTrace);
-                }
+                await _autopilot.TerminateAsync(ExitCode.UnCatchExceptions, logString, stackTrace);
+            }
+            else
+            {
+                await _autopilot.TerminateAsync(ExitCode.AutopilotFailed, logString, stackTrace);
             }
         }
 

--- a/Tests/Runtime/AutopilotTest.cs
+++ b/Tests/Runtime/AutopilotTest.cs
@@ -53,7 +53,7 @@ namespace DeNA.Anjin
             var agents = Object.FindObjectsOfType<AgentInspector>();
             Assume.That(agents, Is.Not.Empty, "Agents are running");
 
-            await autopilot.TerminateAsync(ExitCode.Normally);
+            await autopilot.TerminateAsync(ExitCode.Normally, reporting: false);
             await UniTask.NextFrame(); // wait for destroy
 
             autopilot = Object.FindObjectOfType<Autopilot>(); // re-find after terminated

--- a/Tests/Runtime/TestDoubles/SpyReporter.cs
+++ b/Tests/Runtime/TestDoubles/SpyReporter.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using DeNA.Anjin.Reporters;
-using DeNA.Anjin.Settings;
 using UnityEngine;
 
 namespace DeNA.Anjin.TestDoubles
@@ -13,26 +12,22 @@ namespace DeNA.Anjin.TestDoubles
     /// <summary>
     /// A spy for <c cref="AbstractReporter" />
     /// </summary>
-    // [CreateAssetMenu(fileName = "New SpyReporter", menuName = "Anjin/Spy Reporter", order = 34)]
+    // [CreateAssetMenu(fileName = "New SpyReporter", menuName = "Anjin/Spy Reporter", order = 55)]
     public class SpyReporter : AbstractReporter
     {
         public List<Dictionary<string, string>> Arguments { get; } = new List<Dictionary<string, string>>();
-        
+
         public override async UniTask PostReportAsync(
-            string logString,
+            string message,
             string stackTrace,
-            LogType type,
-            bool withScreenshot,
+            ExitCode exitCode,
             CancellationToken cancellationToken = default
         )
         {
             Debug.Log("Reporter called");
             Arguments.Add(new Dictionary<string, string>
             {
-                {"logString", logString},
-                {"stackTrace", stackTrace},
-                {"type", type.ToString()},
-                {"withScreenshot", withScreenshot.ToString()}
+                { "message", message }, { "stackTrace", stackTrace }, { "exitCode", exitCode.ToString() }
             });
             await UniTask.NextFrame(cancellationToken);
         }

--- a/Tests/Runtime/TestDoubles/SpyTerminatable.cs
+++ b/Tests/Runtime/TestDoubles/SpyTerminatable.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2023-2024 DeNA Co., Ltd.
+// This software is released under the MIT License.
+
+using System.Threading;
+using Cysharp.Threading.Tasks;
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+namespace DeNA.Anjin.TestDoubles
+{
+    public class SpyTerminatable : ITerminatable
+    {
+        public bool IsCalled { get; private set; } = false;
+        public ExitCode CapturedExitCode { get; private set; }
+        public string CapturedMessage { get; private set; }
+        public string CapturedStackTrace { get; private set; }
+        public bool CapturedReporting { get; private set; }
+
+        public async UniTask TerminateAsync(ExitCode exitCode, string message = null, string stackTrace = null,
+            bool reporting = true, CancellationToken token = default)
+        {
+            IsCalled = true;
+            CapturedExitCode = exitCode;
+            CapturedMessage = message;
+            CapturedStackTrace = stackTrace;
+            CapturedReporting = reporting;
+        }
+    }
+}

--- a/Tests/Runtime/TestDoubles/SpyTerminatable.cs.meta
+++ b/Tests/Runtime/TestDoubles/SpyTerminatable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 337802fde88143dda4d8739684434e39
+timeCreated: 1730381729

--- a/Tests/Runtime/Utilities/LogMessageHandlerTest.cs
+++ b/Tests/Runtime/Utilities/LogMessageHandlerTest.cs
@@ -14,211 +14,163 @@ namespace DeNA.Anjin.Utilities
     [TestFixture]
     public class LogMessageHandlerTest
     {
+        private AutopilotSettings _settings;
+        private SpyReporter _spyReporter;
+        private LogMessageHandler _sut;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _settings = ScriptableObject.CreateInstance<AutopilotSettings>();
+            _settings.ignoreMessages = new string[] { };
+            _spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
+            _settings.reporter = _spyReporter;
+            _sut = new LogMessageHandler(_settings);
+        }
+
         [Test]
         public async Task HandleLog_LogTypeIsLog_notReported()
         {
-            var settings = ScriptableObject.CreateInstance<AutopilotSettings>();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-            sut.HandleLog(string.Empty, string.Empty, LogType.Log);
+            _sut.HandleLog(string.Empty, string.Empty, LogType.Log);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Empty);
         }
 
         [Test]
         public async Task HandleLog_LogTypeExceptionHandle_reported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.handleException = true;
-            sut.HandleLog(string.Empty, string.Empty, LogType.Exception);
+            _settings.handleException = true;
+            _sut.HandleLog(string.Empty, string.Empty, LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Not.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Not.Empty);
         }
 
         [Test]
         public async Task HandleLog_LogTypeExceptionNotHandle_notReported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.handleException = false;
-            sut.HandleLog(string.Empty, string.Empty, LogType.Exception);
+            _settings.handleException = false;
+            _sut.HandleLog(string.Empty, string.Empty, LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Empty);
         }
 
         [Test]
         public async Task HandleLog_LogTypeAssertHandle_reported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.handleAssert = true;
-            sut.HandleLog(string.Empty, string.Empty, LogType.Assert);
+            _settings.handleAssert = true;
+            _sut.HandleLog(string.Empty, string.Empty, LogType.Assert);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Not.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Not.Empty);
         }
 
         [Test]
         public async Task HandleLog_LogTypeAssertNotHandle_notReported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.handleAssert = false;
-            sut.HandleLog(string.Empty, string.Empty, LogType.Assert);
+            _settings.handleAssert = false;
+            _sut.HandleLog(string.Empty, string.Empty, LogType.Assert);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Empty);
         }
 
         [Test]
         public async Task HandleLog_LogTypeErrorHandle_reported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.handleError = true;
-            sut.HandleLog(string.Empty, string.Empty, LogType.Error);
+            _settings.handleError = true;
+            _sut.HandleLog(string.Empty, string.Empty, LogType.Error);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Not.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Not.Empty);
         }
 
         [Test]
         public async Task HandleLog_LogTypeErrorNotHandle_notReported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.handleError = false;
-            sut.HandleLog(string.Empty, string.Empty, LogType.Error);
+            _settings.handleError = false;
+            _sut.HandleLog(string.Empty, string.Empty, LogType.Error);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Empty);
         }
 
         [Test]
         public async Task HandleLog_LogTypeWarningHandle_reported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.handleWarning = true;
-            sut.HandleLog(string.Empty, string.Empty, LogType.Warning);
+            _settings.handleWarning = true;
+            _sut.HandleLog(string.Empty, string.Empty, LogType.Warning);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Not.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Not.Empty);
         }
 
         [Test]
         public async Task HandleLog_LogTypeWarningNotHandle_notReported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.handleWarning = false;
-            sut.HandleLog(string.Empty, string.Empty, LogType.Warning);
+            _settings.handleWarning = false;
+            _sut.HandleLog(string.Empty, string.Empty, LogType.Warning);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Empty);
         }
 
         [Test]
         public async Task HandleLog_ContainsIgnoreMessage_notReported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.ignoreMessages = new[] { "ignore" };
-            settings.handleException = true;
-            sut.HandleLog("xxx_ignore_xxx", string.Empty, LogType.Exception);
+            _settings.ignoreMessages = new[] { "ignore" };
+            _settings.handleException = true;
+            _sut.HandleLog("xxx_ignore_xxx", string.Empty, LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Empty);
         }
 
         [Test]
         public async Task HandleLog_MatchIgnoreMessagePattern_notReported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.ignoreMessages = new[] { "ignore.+ignore" };
-            settings.handleException = true;
-            sut.HandleLog("ignore_xxx_ignore", string.Empty, LogType.Exception);
+            _settings.ignoreMessages = new[] { "ignore.+ignore" };
+            _settings.handleException = true;
+            _sut.HandleLog("ignore_xxx_ignore", string.Empty, LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Empty);
         }
 
         [Test]
         public async Task HandleLog_NotMatchIgnoreMessagePattern_Reported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.ignoreMessages = new[] { "ignore.+ignore" };
-            settings.handleException = true;
-            sut.HandleLog("ignore", string.Empty, LogType.Exception);
+            _settings.ignoreMessages = new[] { "ignore.+ignore" };
+            _settings.handleException = true;
+            _sut.HandleLog("ignore", string.Empty, LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Not.Empty);
+            Assert.That(_spyReporter.Arguments, Is.Not.Empty);
         }
 
         [Test]
         public async Task HandleLog_InvalidIgnoreMessagePattern_ThrowArgumentExceptionAndReported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
+            _settings.ignoreMessages = new[] { "[a" }; // invalid pattern
+            _settings.handleException = true;
 
-            settings.ignoreMessages = new[] { "[a" }; // invalid pattern
-            settings.handleException = true;
-
-            sut.HandleLog("ignore", string.Empty, LogType.Exception);
+            _sut.HandleLog("ignore", string.Empty, LogType.Exception);
             await UniTask.NextFrame();
 
             LogAssert.Expect(LogType.Exception, "ArgumentException: parsing \"[a\" - Unterminated [] set.");
-            Assert.That(spyReporter.Arguments, Is.Not.Empty); // Report is executed
+            Assert.That(_spyReporter.Arguments, Is.Not.Empty); // Report is executed
         }
 
         [Test]
         public async Task HandleLog_StacktraceByLogMessageHandler_notReported()
         {
-            var settings = CreateEmptyAutopilotSettings();
-            var spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            var sut = new LogMessageHandler(settings, spyReporter);
-
-            settings.handleException = true;
-            sut.HandleLog(string.Empty, "at DeNA.Anjin.Utilities.LogMessageHandler", LogType.Exception);
+            _settings.handleException = true;
+            _sut.HandleLog(string.Empty, "at DeNA.Anjin.Utilities.LogMessageHandler", LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(spyReporter.Arguments, Is.Empty);
-        }
-
-        private static AutopilotSettings CreateEmptyAutopilotSettings()
-        {
-            var settings = ScriptableObject.CreateInstance<AutopilotSettings>();
-            settings.ignoreMessages = new string[] { };
-            return settings;
+            Assert.That(_spyReporter.Arguments, Is.Empty);
         }
     }
 }

--- a/Tests/Runtime/Utilities/LogMessageHandlerTest.cs
+++ b/Tests/Runtime/Utilities/LogMessageHandlerTest.cs
@@ -15,143 +15,169 @@ namespace DeNA.Anjin.Utilities
     public class LogMessageHandlerTest
     {
         private AutopilotSettings _settings;
-        private SpyReporter _spyReporter;
+        private SpyTerminatable _spyTerminatable;
         private LogMessageHandler _sut;
+
+        private const string Message = "message";
+        private const string StackTrace = "stack trace";
 
         [SetUp]
         public void SetUp()
         {
             _settings = ScriptableObject.CreateInstance<AutopilotSettings>();
+            _settings.lifespanSec = 5;
             _settings.ignoreMessages = new string[] { };
-            _spyReporter = ScriptableObject.CreateInstance<SpyReporter>();
-            _settings.reporter = _spyReporter;
-            _sut = new LogMessageHandler(_settings);
+
+            _spyTerminatable = new SpyTerminatable();
+            _sut = new LogMessageHandler(_settings, _spyTerminatable);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _sut.Dispose();
         }
 
         [Test]
-        public async Task HandleLog_LogTypeIsLog_notReported()
+        public async Task HandleLog_LogTypeIsLog_TerminateIsNotCalled()
         {
-            _sut.HandleLog(string.Empty, string.Empty, LogType.Log);
+            _sut.HandleLog(Message, StackTrace, LogType.Log);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.False);
         }
 
         [Test]
-        public async Task HandleLog_LogTypeExceptionHandle_reported()
+        public async Task HandleLog_LogTypeExceptionHandle_TerminateIsCalled()
         {
             _settings.handleException = true;
-            _sut.HandleLog(string.Empty, string.Empty, LogType.Exception);
+            _sut.HandleLog(Message, StackTrace, LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Not.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.True);
+            Assert.That(_spyTerminatable.CapturedExitCode, Is.EqualTo(ExitCode.UnCatchExceptions));
+            Assert.That(_spyTerminatable.CapturedMessage, Is.EqualTo(Message));
+            Assert.That(_spyTerminatable.CapturedStackTrace, Is.EqualTo(StackTrace));
+            Assert.That(_spyTerminatable.CapturedReporting, Is.True);
         }
 
         [Test]
-        public async Task HandleLog_LogTypeExceptionNotHandle_notReported()
+        public async Task HandleLog_LogTypeExceptionNotHandle_TerminateIsNotCalled()
         {
             _settings.handleException = false;
-            _sut.HandleLog(string.Empty, string.Empty, LogType.Exception);
+            _sut.HandleLog(Message, StackTrace, LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.False);
         }
 
         [Test]
-        public async Task HandleLog_LogTypeAssertHandle_reported()
+        public async Task HandleLog_LogTypeAssertHandle_TerminateIsCalled()
         {
             _settings.handleAssert = true;
-            _sut.HandleLog(string.Empty, string.Empty, LogType.Assert);
+            _sut.HandleLog(Message, StackTrace, LogType.Assert);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Not.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.True);
+            Assert.That(_spyTerminatable.CapturedExitCode, Is.EqualTo(ExitCode.AutopilotFailed));
+            Assert.That(_spyTerminatable.CapturedMessage, Is.EqualTo(Message));
+            Assert.That(_spyTerminatable.CapturedStackTrace, Is.EqualTo(StackTrace));
+            Assert.That(_spyTerminatable.CapturedReporting, Is.True);
         }
 
         [Test]
-        public async Task HandleLog_LogTypeAssertNotHandle_notReported()
+        public async Task HandleLog_LogTypeAssertNotHandle_TerminateIsNotCalled()
         {
             _settings.handleAssert = false;
-            _sut.HandleLog(string.Empty, string.Empty, LogType.Assert);
+            _sut.HandleLog(Message, StackTrace, LogType.Assert);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.False);
         }
 
         [Test]
-        public async Task HandleLog_LogTypeErrorHandle_reported()
+        public async Task HandleLog_LogTypeErrorHandle_TerminateIsCalled()
         {
             _settings.handleError = true;
-            _sut.HandleLog(string.Empty, string.Empty, LogType.Error);
+            _sut.HandleLog(Message, StackTrace, LogType.Error);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Not.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.True);
+            Assert.That(_spyTerminatable.CapturedExitCode, Is.EqualTo(ExitCode.AutopilotFailed));
+            Assert.That(_spyTerminatable.CapturedMessage, Is.EqualTo(Message));
+            Assert.That(_spyTerminatable.CapturedStackTrace, Is.EqualTo(StackTrace));
+            Assert.That(_spyTerminatable.CapturedReporting, Is.True);
         }
 
         [Test]
-        public async Task HandleLog_LogTypeErrorNotHandle_notReported()
+        public async Task HandleLog_LogTypeErrorNotHandle_TerminateIsNotCalled()
         {
             _settings.handleError = false;
-            _sut.HandleLog(string.Empty, string.Empty, LogType.Error);
+            _sut.HandleLog(Message, StackTrace, LogType.Error);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.False);
         }
 
         [Test]
-        public async Task HandleLog_LogTypeWarningHandle_reported()
+        public async Task HandleLog_LogTypeWarningHandle_TerminateIsCalled()
         {
             _settings.handleWarning = true;
-            _sut.HandleLog(string.Empty, string.Empty, LogType.Warning);
+            _sut.HandleLog(Message, StackTrace, LogType.Warning);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Not.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.True);
+            Assert.That(_spyTerminatable.CapturedExitCode, Is.EqualTo(ExitCode.AutopilotFailed));
+            Assert.That(_spyTerminatable.CapturedMessage, Is.EqualTo(Message));
+            Assert.That(_spyTerminatable.CapturedStackTrace, Is.EqualTo(StackTrace));
+            Assert.That(_spyTerminatable.CapturedReporting, Is.True);
         }
 
         [Test]
-        public async Task HandleLog_LogTypeWarningNotHandle_notReported()
+        public async Task HandleLog_LogTypeWarningNotHandle_TerminateIsNotCalled()
         {
             _settings.handleWarning = false;
-            _sut.HandleLog(string.Empty, string.Empty, LogType.Warning);
+            _sut.HandleLog(Message, StackTrace, LogType.Warning);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.False);
         }
 
         [Test]
-        public async Task HandleLog_ContainsIgnoreMessage_notReported()
+        public async Task HandleLog_ContainsIgnoreMessage_TerminateIsNotCalled()
         {
             _settings.ignoreMessages = new[] { "ignore" };
             _settings.handleException = true;
             _sut.HandleLog("xxx_ignore_xxx", string.Empty, LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.False);
         }
 
         [Test]
-        public async Task HandleLog_MatchIgnoreMessagePattern_notReported()
+        public async Task HandleLog_MatchIgnoreMessagePattern_TerminateIsNotCalled()
         {
             _settings.ignoreMessages = new[] { "ignore.+ignore" };
             _settings.handleException = true;
             _sut.HandleLog("ignore_xxx_ignore", string.Empty, LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.False);
         }
 
         [Test]
-        public async Task HandleLog_NotMatchIgnoreMessagePattern_Reported()
+        public async Task HandleLog_NotMatchIgnoreMessagePattern_TerminateIsCalled()
         {
             _settings.ignoreMessages = new[] { "ignore.+ignore" };
             _settings.handleException = true;
             _sut.HandleLog("ignore", string.Empty, LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Not.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.True);
         }
 
         [Test]
-        public async Task HandleLog_InvalidIgnoreMessagePattern_ThrowArgumentExceptionAndReported()
+        public async Task HandleLog_InvalidIgnoreMessagePattern_ThrowArgumentExceptionAndTerminateIsCalled()
         {
             _settings.ignoreMessages = new[] { "[a" }; // invalid pattern
             _settings.handleException = true;
@@ -160,17 +186,17 @@ namespace DeNA.Anjin.Utilities
             await UniTask.NextFrame();
 
             LogAssert.Expect(LogType.Exception, "ArgumentException: parsing \"[a\" - Unterminated [] set.");
-            Assert.That(_spyReporter.Arguments, Is.Not.Empty); // Report is executed
+            Assert.That(_spyTerminatable.IsCalled, Is.True);
         }
 
         [Test]
-        public async Task HandleLog_StacktraceByLogMessageHandler_notReported()
+        public async Task HandleLog_StacktraceByLogMessageHandler_TerminateIsNotCalled()
         {
             _settings.handleException = true;
             _sut.HandleLog(string.Empty, "at DeNA.Anjin.Utilities.LogMessageHandler", LogType.Exception);
             await UniTask.NextFrame();
 
-            Assert.That(_spyReporter.Arguments, Is.Empty);
+            Assert.That(_spyTerminatable.IsCalled, Is.False);
         }
     }
 }

--- a/Tests/TestScenes/Buttons.unity
+++ b/Tests/TestScenes/Buttons.unity
@@ -38,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -223,7 +223,7 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 277263158}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!20 &277263160
 Camera:
   m_ObjectHideFlags: 0
@@ -1939,8 +1939,12 @@ Light:
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
   m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
 --- !u!4 &1741233951
 Transform:
   m_ObjectHideFlags: 0

--- a/Tests/TestScenes/Error.unity
+++ b/Tests/TestScenes/Error.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 10
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -38,13 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481676, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
-  m_GIWorkflowMode: 1
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -67,9 +66,6 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_FinalGather: 0
-    m_FinalGatherFiltering: 1
-    m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
     m_MixedBakeMode: 2
     m_BakeBackend: 1
@@ -193,6 +189,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -335,7 +334,7 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1025330164}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!20 &1025330166
 Camera:
   m_ObjectHideFlags: 0
@@ -476,6 +475,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -561,9 +563,8 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1325883444}
   m_Enabled: 1
-  serializedVersion: 10
+  serializedVersion: 11
   m_Type: 1
-  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
@@ -613,8 +614,12 @@ Light:
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
   m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
 --- !u!4 &1325883446
 Transform:
   m_ObjectHideFlags: 0

--- a/Tests/TestScenes/OutGameTutorial.unity
+++ b/Tests/TestScenes/OutGameTutorial.unity
@@ -38,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.46169513, g: 0.5124164, b: 0.58993304, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -195,8 +195,12 @@ Light:
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
   m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
 --- !u!4 &490633088
 Transform:
   m_ObjectHideFlags: 0
@@ -982,7 +986,7 @@ AudioListener:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1510846388}
-  m_Enabled: 1
+  m_Enabled: 0
 --- !u!20 &1510846390
 Camera:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Before

Reporter posts a report when handling an error.

### After

Reporter posts a report when Autopilot terminates.


### Changes detail

The processing order changes.

Before:

1. LogMessageHandler handles error
    i. Post a report (call reporter async)
    ii. Call Autopilot.TerminateAsync
        a. Terminated

After:

1. LogMessageHandler handles error
    i. Call Autopilot.TerminateAsync
2. Autopilot.TerminateAsync
    i. Post a report (call reporter async)
    ii. Terminated

This change achieved the following:

- Can also report on normally terminated
- Fix to prevent multiple report


### Priority

I hope to review && merge in this week if possible.
There is no need to release it yet.


---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).