### PR TITLE
Add SceneCrossingAgents (ObserverAgent is obsolete)

### DIFF
--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -43,13 +43,13 @@ msgstr "フォールバックAgent"
 msgid "Agent for when not assigned"
 msgstr "割り当てのないSceneのときに使われるAgent"
 
-# observerAgent
-msgid "Observer Agent"
-msgstr "オブザーバーAgent"
+# sceneCrossingAgents
+msgid "Scene Crossing Agents"
+msgstr "Scene横断Agents"
 
-# observerAgent tooltip
-msgid "Parallel running agent using on every scene, for using observer (e.g., EmergencyExitAgent)"
-msgstr "Sceneに関わらず並列実行されるAgent。一般的にはEmergencyExitAgentを割り当てます"
+# sceneCrossingAgents tooltip
+msgid "Agents running by scene crossing. The specified agents will have the same lifespan as Autopilot (i.e., use DontDestroyOnLoad) for specifying, e.g., LogMessageHandlerAgent and UGUIEmergencyExitAgent."
+msgstr "Sceneを横断して実行されるAgent。指定されたAgentの寿命は Autopilot と同じになります（つまり、DontDestroyOnLoad を使用します）。たとえば、LogMessageHandlerAgent や UGUIEmergencyExitAgent などを指定します"
 
 # Header: Autopilot Run Settings
 msgid "Autopilot Run Settings"

--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -48,8 +48,8 @@ msgid "Scene Crossing Agents"
 msgstr "Scene横断Agents"
 
 # sceneCrossingAgents tooltip
-msgid "Agents running by scene crossing. The specified agents will have the same lifespan as Autopilot (i.e., use DontDestroyOnLoad) for specifying, e.g., LogMessageHandlerAgent and UGUIEmergencyExitAgent."
-msgstr "Sceneを横断して実行されるAgent。指定されたAgentの寿命は Autopilot と同じになります（つまり、DontDestroyOnLoad を使用します）。たとえば、LogMessageHandlerAgent や UGUIEmergencyExitAgent などを指定します"
+msgid "Agents running by scene crossing. The specified agents will have the same lifespan as Autopilot (i.e., use DontDestroyOnLoad) for specifying, e.g., ErrorHandlerAgent and UGUIEmergencyExitAgent."
+msgstr "Sceneを横断して実行されるAgent。指定されたAgentの寿命は Autopilot と同じになります（つまり、DontDestroyOnLoad を使用します）。たとえば、ErrorHandlerAgent や UGUIEmergencyExitAgent などを指定します"
 
 # Header: Autopilot Run Settings
 msgid "Autopilot Run Settings"

--- a/Editor/UI/Settings/AutopilotSettingsEditor.cs
+++ b/Editor/UI/Settings/AutopilotSettingsEditor.cs
@@ -14,6 +14,7 @@ namespace DeNA.Anjin.Editor.UI.Settings
     [CustomEditor(typeof(AutopilotSettings))]
     public class AutopilotSettingsEditor : UnityEditor.Editor
     {
+        // @formatter:off
         private static readonly string s_description = L10n.Tr("Description");
         private static readonly string s_descriptionTooltip = L10n.Tr("Description about this setting instance");
 
@@ -22,17 +23,13 @@ namespace DeNA.Anjin.Editor.UI.Settings
         private static readonly string s_sceneAgentMapsTooltip = L10n.Tr("Scene to Agent assign mapping");
         private static readonly string s_fallbackAgent = L10n.Tr("Fallback Agent");
         private static readonly string s_fallbackAgentTooltip = L10n.Tr("Agent for when not assigned");
-        private static readonly string s_observerAgent = L10n.Tr("Observer Agent");
 
-        private static readonly string s_observerAgentTooltip =
-            L10n.Tr("Parallel running agent using on every scene, for using observer (e.g., EmergencyExitAgent)");
+        private static readonly string s_sceneCrossingAgents = L10n.Tr("Scene Crossing Agents");
+        private static readonly string s_sceneCrossingAgentsTooltip = L10n.Tr("Agents running by scene crossing. The specified agents will have the same lifespan as Autopilot (i.e., use DontDestroyOnLoad) for specifying, e.g., LogMessageHandlerAgent and UGUIEmergencyExitAgent.");
 
         private static readonly string s_autopilotRunSettingsHeader = L10n.Tr("Autopilot Run Settings");
         private static readonly string s_lifespanSec = L10n.Tr("Lifespan Sec");
-
-        private static readonly string s_lifespanSecTooltip =
-            L10n.Tr("Autopilot running lifespan [sec]. When specified zero, so unlimited running");
-
+        private static readonly string s_lifespanSecTooltip = L10n.Tr("Autopilot running lifespan [sec]. When specified zero, so unlimited running");
         private static readonly string s_randomSeed = L10n.Tr("Random Seed");
         private static readonly string s_randomSeedTooltip = L10n.Tr("Random using the specified seed value");
         private static readonly string s_timeScale = L10n.Tr("Time Scale");
@@ -42,15 +39,10 @@ namespace DeNA.Anjin.Editor.UI.Settings
         private static readonly string s_junitReportPathTooltip = L10n.Tr("JUnit report output path");
 
         private static readonly string s_loggers = L10n.Tr("Loggers");
-
-        private static readonly string s_loggersTooltip =
-            L10n.Tr(
-                "List of Loggers used for this autopilot settings. If omitted, Debug.unityLogger will be used as default.");
+        private static readonly string s_loggersTooltip = L10n.Tr("List of Loggers used for this autopilot settings. If omitted, Debug.unityLogger will be used as default.");
 
         private static readonly string s_reporters = L10n.Tr("Reporters");
-
-        private static readonly string s_reportersTooltip =
-            L10n.Tr("List of Reporters to be called on Autopilot terminate.");
+        private static readonly string s_reportersTooltip = L10n.Tr("List of Reporters to be called on Autopilot terminate.");
 
         private static readonly string s_errorHandlingSettingsHeader = L10n.Tr("Error Handling Settings");
         private static readonly string s_handleException = L10n.Tr("Handle Exception");
@@ -62,14 +54,13 @@ namespace DeNA.Anjin.Editor.UI.Settings
         private static readonly string s_handleWarning = L10n.Tr("Handle Warning");
         private static readonly string s_handleWarningTooltip = L10n.Tr("Notify when Warning detected in log");
         private static readonly string s_ignoreMessages = L10n.Tr("Ignore Messages");
-
-        private static readonly string s_ignoreMessagesTooltip =
-            L10n.Tr("Do not send notifications when log messages contain this string");
+        private static readonly string s_ignoreMessagesTooltip = L10n.Tr("Do not send notifications when log messages contain this string");
 
         private static readonly string s_runButton = L10n.Tr("Run");
         private static readonly string s_stopButton = L10n.Tr("Stop");
         private const float SpacerPixels = 10f;
         private const float SpacerPixelsUnderHeader = 4f;
+        // @formatter:on
 
         /// <inheritdoc/>
         public override void OnInspectorGUI()
@@ -84,8 +75,8 @@ namespace DeNA.Anjin.Editor.UI.Settings
                 new GUIContent(s_sceneAgentMaps, s_sceneAgentMapsTooltip), true);
             EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(AutopilotSettings.fallbackAgent)),
                 new GUIContent(s_fallbackAgent, s_fallbackAgentTooltip));
-            EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(AutopilotSettings.observerAgent)),
-                new GUIContent(s_observerAgent, s_observerAgentTooltip));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(AutopilotSettings.sceneCrossingAgents)),
+                new GUIContent(s_sceneCrossingAgents, s_sceneCrossingAgentsTooltip));
 
             DrawHeader(s_autopilotRunSettingsHeader);
             EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(AutopilotSettings.lifespanSec)),

--- a/Editor/UI/Settings/AutopilotSettingsEditor.cs
+++ b/Editor/UI/Settings/AutopilotSettingsEditor.cs
@@ -25,7 +25,7 @@ namespace DeNA.Anjin.Editor.UI.Settings
         private static readonly string s_fallbackAgentTooltip = L10n.Tr("Agent for when not assigned");
 
         private static readonly string s_sceneCrossingAgents = L10n.Tr("Scene Crossing Agents");
-        private static readonly string s_sceneCrossingAgentsTooltip = L10n.Tr("Agents running by scene crossing. The specified agents will have the same lifespan as Autopilot (i.e., use DontDestroyOnLoad) for specifying, e.g., LogMessageHandlerAgent and UGUIEmergencyExitAgent.");
+        private static readonly string s_sceneCrossingAgentsTooltip = L10n.Tr("Agents running by scene crossing. The specified agents will have the same lifespan as Autopilot (i.e., use DontDestroyOnLoad) for specifying, e.g., ErrorHandlerAgent and UGUIEmergencyExitAgent.");
 
         private static readonly string s_autopilotRunSettingsHeader = L10n.Tr("Autopilot Run Settings");
         private static readonly string s_lifespanSec = L10n.Tr("Lifespan Sec");

--- a/README.md
+++ b/README.md
@@ -103,14 +103,12 @@ If a Scene does not exist in the list, the Agent set in `Fallback Agent` will be
 For example, if you want `UGUIMonkeyAgent` to work for all Scenes, set `Scene Agent Maps` to empty, and set
 Set the `Fallback Agent` to an `UGUIMonkeyAgent`'s .asset file.
 
-##### Observer Agent
+##### Scene Crossing Agents
 
-Set the Agents to always be launched in parallel, independent of `Scene Agent Maps` and `Fallback Agent`.
-As of v1.0.0, `EmergencyExitAgent` is assumed to be used.
-If you need to launch multiple Agents in parallel, use `ParallelCompositeAgent`.
+Set the Agents to run by scene crossing, independent of `Scene Agent Maps` and `Fallback Agent`.
 
-Note that the Agents set here will be destroyed and created each time a new Scene is loaded.
-It is **NOT** set to `DontDestroyOnLoad`.
+The specified agents will have the same lifespan as Autopilot (i.e., use `DontDestroyOnLoad`)
+for specifying, e.g., `LogMessageHandlerAgent` and `UGUIEmergencyExitAgent`.
 
 #### Autopilot Run Settings
 
@@ -385,7 +383,7 @@ An Agent that monitors the appearance of the `EmergencyExitAnnotations` componen
 This can be used in games that contain behavior that is irregular in the execution of the test scenario, for example, communication errors or "return to title screen" buttons that are triggered by a daybreak.
 
 It should always be started at the same time as other Agents (that actually perform game operations).
-This can be accomplished with `ParallelCompositeAgent`, but it is easier to set it up as an `ObserverAgent` in AutopilotSettings.
+This can be accomplished with `ParallelCompositeAgent`, but it is easier to set it up as an `Scene Crossing Agents` in AutopilotSettings.
 
 
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Set the `Fallback Agent` to an `UGUIMonkeyAgent`'s .asset file.
 Set the Agents to run by scene crossing, independent of `Scene Agent Maps` and `Fallback Agent`.
 
 The specified agents will have the same lifespan as Autopilot (i.e., use `DontDestroyOnLoad`)
-for specifying, e.g., `LogMessageHandlerAgent` and `UGUIEmergencyExitAgent`.
+for specifying, e.g., `ErrorHandlerAgent` and `UGUIEmergencyExitAgent`.
 
 #### Autopilot Run Settings
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -101,13 +101,12 @@ Sceneごとに自動実行を行なうAgent設定ファイル（.asset）の対�
 たとえば全てのSceneで `UGUIMonkeyAgent` が動くようにしたければ、`Scene Agent Maps` は空に、
 `Fallback Agent` には `UGUIMonkeyAgent` の.assetファイルを設定します。
 
-##### オブザーバーAgent
+##### Scene横断Agents
 
-`Scene Agent Maps`と`Fallback Agent`とは独立して、常に並列に起動されるAgentを設定します。
-v1.0.0時点では `EmergencyExitAgent` の使用を想定しています。
-複数のAgentを並列起動する必要があるときは `ParallelCompositeAgent` を使用してください。
+`Scene Agent Maps` および `Fallback Agent`とは独立して、Sceneを横断して実行されるAgentを設定します。
 
-なお、ここに設定されたAgentは `DontDestroyOnLoad` **ではなく**、新しいSceneがロードされる度に破棄・生成される点に注意してください。
+指定されたAgentの寿命はオートパイロット本体と同じになります（つまり、`DontDestroyOnLoad` を使用します）。
+たとえば、`LogMessageHandlerAgent` や `UGUIEmergencyExitAgent` などを指定します。
 
 #### オートパイロット実行設定
 
@@ -389,7 +388,7 @@ SerialCompositeAgentと組み合わせることで、一連の操作を何周も
 たとえば通信エラーや日またぎで「タイトル画面に戻る」ボタンのような、テストシナリオ遂行上イレギュラーとなる振る舞いが含まれるゲームで利用できます。
 
 常に、他の（実際にゲーム操作を行なう）Agentと同時に起動しておく必要があります。
-`ParallelCompositeAgent` でも実現できますが、AutopilotSettingsに `Observer Agent` として設定するほうが簡単です。
+`ParallelCompositeAgent` でも実現できますが、AutopilotSettingsの `Scene Crossing Agents` に追加するほうが簡単です。
 
 
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -106,7 +106,7 @@ Sceneごとに自動実行を行なうAgent設定ファイル（.asset）の対�
 `Scene Agent Maps` および `Fallback Agent`とは独立して、Sceneを横断して実行されるAgentを設定します。
 
 指定されたAgentの寿命はオートパイロット本体と同じになります（つまり、`DontDestroyOnLoad` を使用します）。
-たとえば、`LogMessageHandlerAgent` や `UGUIEmergencyExitAgent` などを指定します。
+たとえば、`ErrorHandlerAgent` や `UGUIEmergencyExitAgent` などを指定します。
 
 #### オートパイロット実行設定
 

--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -68,6 +68,7 @@ namespace DeNA.Anjin
             _logMessageHandler = new LogMessageHandler(_settings, this);
 
             _dispatcher = new AgentDispatcher(_settings, _logger, _randomFactory);
+            _dispatcher.DispatchSceneCrossingAgents();
             var dispatched = _dispatcher.DispatchByScene(SceneManager.GetActiveScene(), false);
             if (!dispatched)
             {

--- a/Runtime/Settings/AutopilotSettings.cs
+++ b/Runtime/Settings/AutopilotSettings.cs
@@ -69,7 +69,7 @@ namespace DeNA.Anjin.Settings
         /// <summary>
         /// Agents running by scene crossing.
         /// The specified agents will have the same lifespan as <c>Autopilot</c> (i.e., use <c>DontDestroyOnLoad</c>)
-        /// for specifying, e.g., <c>LogMessageHandlerAgent</c>, <c>UGUIEmergencyExitAgent</c>.
+        /// for specifying, e.g., <c>ErrorHandlerAgent</c>, <c>UGUIEmergencyExitAgent</c>.
         /// </summary>
         public List<AbstractAgent> sceneCrossingAgents = new List<AbstractAgent>();
 

--- a/Runtime/Settings/AutopilotSettings.cs
+++ b/Runtime/Settings/AutopilotSettings.cs
@@ -63,7 +63,15 @@ namespace DeNA.Anjin.Settings
         /// <summary>
         /// Parallel running agent using on every scene, for using observer (e.g., EmergencyExitAgent)
         /// </summary>
+        [Obsolete("Use crossSceneAgents instead")]
         public AbstractAgent observerAgent;
+
+        /// <summary>
+        /// Agents running by scene crossing.
+        /// The specified agents will have the same lifespan as <c>Autopilot</c> (i.e., use <c>DontDestroyOnLoad</c>)
+        /// for specifying, e.g., <c>LogMessageHandlerAgent</c>, <c>UGUIEmergencyExitAgent</c>.
+        /// </summary>
+        public List<AbstractAgent> sceneCrossingAgents = new List<AbstractAgent>();
 
         /// <summary>
         /// Autopilot running lifespan [sec]. When specified zero, so unlimited running
@@ -344,6 +352,21 @@ This time, temporarily generate and use SlackReporter instance.";
             var dir = Path.GetDirectoryName(settingsPath) ?? "Assets";
             AssetDatabase.CreateAsset(obj, Path.Combine(dir, $"New {obj.GetType().Name}.asset"));
 #endif
+        }
+
+        [Obsolete("Remove this method when bump major version")]
+        internal void ConvertSceneCrossingAgentsFromObsoleteObserverAgent(ILogger logger)
+        {
+            if (this.observerAgent == null || this.sceneCrossingAgents.Any())
+            {
+                return;
+            }
+
+            logger.Log(LogType.Warning, @"ObserverAgent setting in AutopilotSettings has been obsolete.
+Please delete the value using Debug Mode in the Inspector window. And using the SceneCrossingAgents.
+This time, temporarily converting.");
+
+            this.sceneCrossingAgents.Add(this.observerAgent);
         }
     }
 }


### PR DESCRIPTION
### Before

- ObserverAgent can set a single Agent.
- ObserverAgent is dispatched when loading any scene and disposes when unloading that scene.

### After

- Multiple agents can be set in SceneCrossingAgents.
- SceneCrossingAgents will have the same lifespan as Autopilot (i.e., use `DontDestroyOnLoad`).

### Priority

I hope to your review && merge around one week.
There is no need to release it yet.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).