### PR TITLE
Fix to reset instances when domain reloading is disabled

### DIFF
--- a/Runtime/Agents/ErrorHandlerAgent.cs
+++ b/Runtime/Agents/ErrorHandlerAgent.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using DeNA.Anjin.Attributes;
 using DeNA.Anjin.Reporters.Slack;
 using DeNA.Anjin.Settings;
 using UnityEngine;
@@ -64,6 +65,19 @@ namespace DeNA.Anjin.Agents
         internal ITerminatable _autopilot; // can inject for testing
         private List<Regex> _ignoreMessagesRegexes;
         private CancellationToken _token;
+
+        [InitializeOnLaunchAutopilot]
+        private static void ResetInstances()
+        {
+            // Reset runtime instances
+            var agents = Resources.FindObjectsOfTypeAll<ErrorHandlerAgent>();
+            foreach (var agent in agents)
+            {
+                agent._autopilot = null;
+                agent._ignoreMessagesRegexes = null;
+                agent._token = default;
+            }
+        }
 
         public override async UniTask Run(CancellationToken token)
         {

--- a/Runtime/Agents/OneTimeAgent.cs
+++ b/Runtime/Agents/OneTimeAgent.cs
@@ -26,7 +26,7 @@ namespace DeNA.Anjin.Agents
         public static void ResetExecutedFlag()
         {
             // Reset runtime instances
-            var oneTimeAgents = FindObjectsOfType<OneTimeAgent>();
+            var oneTimeAgents = Resources.FindObjectsOfTypeAll<OneTimeAgent>();
             foreach (var current in oneTimeAgents)
             {
                 current.WasExecuted = false;

--- a/Runtime/Agents/TimeBombAgent.cs
+++ b/Runtime/Agents/TimeBombAgent.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using DeNA.Anjin.Attributes;
 using UnityEngine;
 
 namespace DeNA.Anjin.Agents
@@ -32,8 +33,35 @@ namespace DeNA.Anjin.Agents
         public string defuseMessage;
 
         internal ITerminatable _autopilot; // can inject for testing
-        private Regex DefuseMessageRegex => new Regex(defuseMessage);
         private CancellationTokenSource _cts;
+        private Regex _defuseMessageRegex;
+
+        private Regex DefuseMessageRegex
+        {
+            get
+            {
+                if (_defuseMessageRegex == null)
+                {
+                    _defuseMessageRegex = new Regex(defuseMessage);
+                }
+
+                return _defuseMessageRegex;
+            }
+            set { _defuseMessageRegex = value; }
+        }
+
+        [InitializeOnLaunchAutopilot]
+        private static void ResetInstances()
+        {
+            // Reset runtime instances
+            var agents = Resources.FindObjectsOfTypeAll<TimeBombAgent>();
+            foreach (var agent in agents)
+            {
+                agent._autopilot = null;
+                agent._cts = null;
+                agent.DefuseMessageRegex = null;
+            }
+        }
 
         private void OnEnable()
         {

--- a/Runtime/Agents/UGUIMonkeyAgent.cs
+++ b/Runtime/Agents/UGUIMonkeyAgent.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using DeNA.Anjin.Attributes;
 using DeNA.Anjin.Strategies;
 using DeNA.Anjin.Utilities;
 using TestHelper.Monkey;
@@ -96,6 +97,17 @@ namespace DeNA.Anjin.Agents
             ScreenCapture.StereoScreenCaptureMode.LeftEye;
 
         internal ITerminatable _autopilot; // can inject for testing
+
+        [InitializeOnLaunchAutopilot]
+        private static void ResetInstances()
+        {
+            // Reset runtime instances
+            var agents = Resources.FindObjectsOfTypeAll<UGUIMonkeyAgent>();
+            foreach (var agent in agents)
+            {
+                agent._autopilot = null;
+            }
+        }
 
         /// <inheritdoc />
         public override async UniTask Run(CancellationToken token)


### PR DESCRIPTION
### Before

Not reset instance fields (not serialized) in ScriptableObjects when domain reloading is disabled.

### After

Reset all instance fields (not serialized) in ScriptableObjects when even domain reloading is disabled.

### Priority

I hope to your review && merge around one week.
There is no need to release it yet.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).