### PR TITLE
Teardown when Play Mode is stopped while the Autopilot running

### DIFF
--- a/Editor/Commandline.cs
+++ b/Editor/Commandline.cs
@@ -55,9 +55,6 @@ namespace DeNA.Anjin.Editor
             // Set first open Scene
             EditorSceneManager.playModeStartScene = myWantedStartScene;
 
-            // Register event handler for terminate autopilot
-            EditorApplication.playModeStateChanged += OnChangePlayModeState;
-
             // Activate autopilot and enter play mode
             var state = AutopilotState.Instance;
             state.launchFrom = LaunchType.Commandline;
@@ -96,27 +93,6 @@ namespace DeNA.Anjin.Editor
                 : "UnityEditor.PlayModeView";
             var gameView = assembly.GetType(viewClass);
             EditorWindow.GetWindow(gameView, false, null, true);
-        }
-
-        /// <summary>
-        /// Stop autopilot on play mode exit event when run on Unity editor.
-        /// Not called when invoked from play mode (not registered in event listener).
-        /// </summary>
-        /// <param name="playModeStateChange"></param>
-        private static void OnChangePlayModeState(PlayModeStateChange playModeStateChange)
-        {
-            if (playModeStateChange != PlayModeStateChange.EnteredEditMode)
-            {
-                return;
-            }
-
-            EditorApplication.playModeStateChanged -= OnChangePlayModeState;
-
-            // Exit Unity when returning from play mode to edit mode.
-            // Because it may freeze when exiting without going through edit mode.
-            var exitCode = (int)AutopilotState.Instance.exitCode;
-            Debug.Log($"Exit Unity-editor by autopilot, exit code: {(int)exitCode}");
-            EditorApplication.Exit(exitCode);
         }
     }
 }

--- a/Editor/UI/Settings/AutopilotSettingsEditor.cs
+++ b/Editor/UI/Settings/AutopilotSettingsEditor.cs
@@ -112,6 +112,7 @@ namespace DeNA.Anjin.Editor.UI.Settings
         // ReSharper disable once MemberCanBeMadeStatic.Global
         internal void Stop()
         {
+            EditorApplication.playModeStateChanged -= OnChangePlayModeState;
             Autopilot.Instance.TerminateAsync(ExitCode.Normally, reporting: false).Forget();
         }
 
@@ -130,6 +131,24 @@ namespace DeNA.Anjin.Editor.UI.Settings
                 state.launchFrom = LaunchType.EditMode;
                 EditorApplication.isPlaying = true;
             }
+
+            EditorApplication.playModeStateChanged += OnChangePlayModeState;
+        }
+
+        /// <summary>
+        /// Teardown when Play Mode is stopped while the Autopilot is running.
+        /// </summary>
+        private static void OnChangePlayModeState(PlayModeStateChange playModeStateChange)
+        {
+            if (playModeStateChange != PlayModeStateChange.EnteredEditMode)
+            {
+                return;
+            }
+
+            EditorApplication.playModeStateChanged -= OnChangePlayModeState;
+
+            Debug.LogWarning("Play Mode is stopped while the Autopilot is running");
+            AutopilotState.Instance.Reset();
         }
     }
 }

--- a/Editor/UI/Settings/AutopilotSettingsEditor.cs
+++ b/Editor/UI/Settings/AutopilotSettingsEditor.cs
@@ -112,7 +112,6 @@ namespace DeNA.Anjin.Editor.UI.Settings
         // ReSharper disable once MemberCanBeMadeStatic.Global
         internal void Stop()
         {
-            EditorApplication.playModeStateChanged -= OnChangePlayModeState;
             Autopilot.Instance.TerminateAsync(ExitCode.Normally, reporting: false).Forget();
         }
 
@@ -131,24 +130,6 @@ namespace DeNA.Anjin.Editor.UI.Settings
                 state.launchFrom = LaunchType.EditMode;
                 EditorApplication.isPlaying = true;
             }
-
-            EditorApplication.playModeStateChanged += OnChangePlayModeState;
-        }
-
-        /// <summary>
-        /// Teardown when Play Mode is stopped while the Autopilot is running.
-        /// </summary>
-        private static void OnChangePlayModeState(PlayModeStateChange playModeStateChange)
-        {
-            if (playModeStateChange != PlayModeStateChange.EnteredEditMode)
-            {
-                return;
-            }
-
-            EditorApplication.playModeStateChanged -= OnChangePlayModeState;
-
-            Debug.LogWarning("Play Mode is stopped while the Autopilot is running");
-            AutopilotState.Instance.Reset();
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -665,7 +665,15 @@ It can specify the same arguments as when running in the editor.
 
 ## Troubleshooting
 
-### Autopilot runs on its own in play mode.
+### Autopilot is stopped, but the Run button in AutopilotSettings does not appear
+
+The `AutopilotState.asset` that persists in Anjin's execution state may be in an incorrect state.
+Open it in the inspector and click the **Reset** button.
+
+If this does not solve the problem, try deleting `AutopilotState.asset`.
+
+
+### Autopilot runs on its own in play mode
 
 The `AutopilotState.asset` that persists in Anjin's execution state may be in an incorrect state.
 Open it in the inspector and click the **Reset** button.

--- a/README_ja.md
+++ b/README_ja.md
@@ -676,6 +676,14 @@ $(ROM) -LAUNCH_AUTOPILOT_SETTINGS Path/To/AutopilotSettings
 
 ## トラブルシューティング
 
+### オートパイロットは停止しているのに AutopilotSettings の Run ボタンが表示されない
+
+Anjinの実行状態を永続化している `AutopilotState.asset` が不正な状態になっている恐れがあります。
+インスペクタで開いて**Reset**ボタンをクリックしてください。
+
+それでも解決しない場合、 `AutopilotState.asset` を削除してみてください。
+
+
 ### プロジェクトを再生モードにすると勝手にオートパイロットが動いてしまう
 
 Anjinの実行状態を永続化している `AutopilotState.asset` が不正な状態になっている恐れがあります。

--- a/Runtime/Launcher.cs
+++ b/Runtime/Launcher.cs
@@ -247,7 +247,7 @@ namespace DeNA.Anjin
                 await UniTask.NextFrame();
 #if UNITY_EDITOR
                 EditorApplication.isPlaying = false;
-                // Note: If launched from the command line, `DeNA.Anjin.Editor.Commandline.OnChangePlayModeState()` will be called, and the Unity editor will be terminated.
+                // Note: If launched from the command line, `DeNA.Anjin.Autopilot.OnExitPlayModeToTerminateEditor()` will be called, and the Unity editor will be terminated.
 #endif
             }
             else


### PR DESCRIPTION
### Problem

The `AutopilotState` asset still contained information that the autopilot was running, so it had to be reset.

Condition: When a user stops Play Mode while the Autopilot is running.

### Fixes

Reset the `AutopilotState` when Play Mode is stopped while the Autopilot is running,
using `EditorApplication.playModeStateChanged` event.

This behavior was tested enable and disable domain reloading in Enter Play Mode Settings.

Minor fixes: Improved the exit process when launching from the commandline.

### Priority

I hope to your review && merge around one week.
There is no need to release it yet.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).