### PR TITLE
Fix to support Unity 2020.2 or older

### DIFF
--- a/Editor/UI/Settings/AutopilotSettingsEditor.cs
+++ b/Editor/UI/Settings/AutopilotSettingsEditor.cs
@@ -145,7 +145,9 @@ namespace DeNA.Anjin.Editor.UI.Settings
             else
             {
                 state.launchFrom = LaunchType.EditMode;
+#if UNITY_2020_3_OR_NEWER
                 AssetDatabase.SaveAssetIfDirty(state); // Note: Sync with virtual players of MPPM package
+#endif
                 EditorApplication.isPlaying = true;
             }
         }

--- a/Runtime/Launcher.cs
+++ b/Runtime/Launcher.cs
@@ -224,7 +224,7 @@ namespace DeNA.Anjin
         {
             state.settings = null;
             state.exitCode = exitCode;
-#if UNITY_EDITOR
+#if UNITY_EDITOR && UNITY_2020_3_OR_NEWER
             AssetDatabase.SaveAssetIfDirty(state); // Note: Sync with virtual players of MPPM package
 #endif
 

--- a/Runtime/Settings/AutopilotSettings.cs
+++ b/Runtime/Settings/AutopilotSettings.cs
@@ -323,7 +323,7 @@ namespace DeNA.Anjin.Settings
             settings.ConvertSceneCrossingAgentsFromObsoleteObserverAgent(logger); // Note: before convert other Agents.
             settings.ConvertErrorHandlerAgentFromObsoleteSettings(logger);
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && UNITY_2020_3_OR_NEWER
             AssetDatabase.SaveAssetIfDirty(settings);
 #endif
         }

--- a/Runtime/Settings/AutopilotState.cs
+++ b/Runtime/Settings/AutopilotState.cs
@@ -46,7 +46,7 @@ namespace DeNA.Anjin.Settings
             launchFrom = LaunchType.NotSet;
             settings = null;
             exitCode = ExitCode.Normally;
-#if UNITY_EDITOR
+#if UNITY_EDITOR && UNITY_2020_3_OR_NEWER
             AssetDatabase.SaveAssetIfDirty(this); // Note: Sync with virtual players of MPPM package
 #endif
         }


### PR DESCRIPTION
### Fixes

Fix to not call `AssetDatabase.SaveAssetIfDirty()` in Unity 2020.2 or older.
This API is added in Unity 2020.3.

Not offer an alternative because this is an optional feature.

refs #110 #111 

### Priority

I hope to your review && merge around one week.
There is no need to release it yet.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).