### PR TITLE
Set dirty flag when change AutopilotState

### DIFF
--- a/Editor/UI/Settings/AutopilotSettingsEditor.cs
+++ b/Editor/UI/Settings/AutopilotSettingsEditor.cs
@@ -161,6 +161,7 @@ namespace DeNA.Anjin.Editor.UI.Settings
             {
                 state.launchFrom = LaunchType.EditMode;
 #if UNITY_2020_3_OR_NEWER
+                EditorUtility.SetDirty(state);
                 AssetDatabase.SaveAssetIfDirty(state); // Note: Sync with virtual players of MPPM package
 #endif
                 EditorApplication.isPlaying = true;

--- a/Runtime/Launcher.cs
+++ b/Runtime/Launcher.cs
@@ -222,6 +222,7 @@ namespace DeNA.Anjin
             state.settings = null;
             state.exitCode = exitCode;
 #if UNITY_EDITOR && UNITY_2020_3_OR_NEWER
+            EditorUtility.SetDirty(state);
             AssetDatabase.SaveAssetIfDirty(state); // Note: Sync with virtual players of MPPM package
 #endif
 

--- a/Runtime/Settings/AutopilotState.cs
+++ b/Runtime/Settings/AutopilotState.cs
@@ -47,6 +47,7 @@ namespace DeNA.Anjin.Settings
             settings = null;
             exitCode = ExitCode.Normally;
 #if UNITY_EDITOR && UNITY_2020_3_OR_NEWER
+            EditorUtility.SetDirty(this);
             AssetDatabase.SaveAssetIfDirty(this); // Note: Sync with virtual players of MPPM package
 #endif
         }


### PR DESCRIPTION
### Fixes

Set a dirty flag when changing `AutopilotState`.
Ensuring state reflection when using MPPM packages.

This fix is being made because the correction in #110 is insufficient.

### Priority

I hope to your review && merge in this week.
There is no need to release it yet.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).