### PR TITLE
Fix FileLogger doesn't work when Autopilot is stopped and re-run

### DIFF
--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -148,7 +148,6 @@ namespace DeNA.Anjin
 
             _logger?.Log("Destroy Autopilot object");
             _dispatcher?.Dispose();
-            _settings.LoggerAsset?.Dispose();
         }
 
         /// <inheritdoc/>

--- a/Runtime/Loggers/AbstractLoggerAsset.cs
+++ b/Runtime/Loggers/AbstractLoggerAsset.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2023-2024 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
-using System;
 using UnityEngine;
 
 namespace DeNA.Anjin.Loggers
@@ -9,21 +8,19 @@ namespace DeNA.Anjin.Loggers
     /// <summary>
     /// Abstract logger settings used for autopilot.
     /// </summary>
-    public abstract class AbstractLoggerAsset : ScriptableObject, IDisposable
+    public abstract class AbstractLoggerAsset : ScriptableObject
     {
 #if UNITY_EDITOR
         /// <summary>
         /// Description about this agent instance.
         /// </summary>
-        [Multiline] public string description;
+        [Multiline]
+        public string description;
 #endif
 
         /// <summary>
         /// Logger implementation used for autopilot.
         /// </summary>
         public abstract ILogger Logger { get; }
-
-        /// <inheritdoc />
-        public abstract void Dispose();
     }
 }

--- a/Runtime/Loggers/CompositeLoggerAsset.cs
+++ b/Runtime/Loggers/CompositeLoggerAsset.cs
@@ -39,13 +39,7 @@ namespace DeNA.Anjin.Loggers
             }
         }
 
-        /// <inheritdoc />
-        public override void Dispose()
-        {
-            _handler?.Dispose();
-        }
-
-        private class CompositeLogHandler : ILogHandler, IDisposable
+        private class CompositeLogHandler : ILogHandler
         {
             private readonly List<AbstractLoggerAsset> _loggerAssets;
             private readonly AbstractLoggerAsset _owner;
@@ -71,15 +65,6 @@ namespace DeNA.Anjin.Loggers
                 foreach (var loggerAsset in _loggerAssets.Where(x => x != null && x != _owner))
                 {
                     loggerAsset.Logger.LogException(exception, context);
-                }
-            }
-
-            /// <inheritdoc />
-            public void Dispose()
-            {
-                foreach (var loggerAsset in _loggerAssets.Where(x => x != null && x != _owner))
-                {
-                    loggerAsset.Dispose();
                 }
             }
         }

--- a/Runtime/Loggers/ConsoleLoggerAsset.cs
+++ b/Runtime/Loggers/ConsoleLoggerAsset.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2023-2024 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
-using DeNA.Anjin.Attributes;
 using UnityEngine;
 
 namespace DeNA.Anjin.Loggers
@@ -32,23 +31,6 @@ namespace DeNA.Anjin.Loggers
 
                 _logger = new Logger(Debug.unityLogger.logHandler) { filterLogType = filterLogType };
                 return _logger;
-            }
-        }
-
-        /// <inheritdoc />
-        public override void Dispose()
-        {
-            // Nothing to dispose.
-        }
-
-        [InitializeOnLaunchAutopilot(InitializeOnLaunchAutopilotAttribute.InitializeLoggerOrder)]
-        public static void ResetLoggers()
-        {
-            // Reset runtime instances
-            var loggerAssets = FindObjectsOfType<ConsoleLoggerAsset>();
-            foreach (var current in loggerAssets)
-            {
-                current._logger = null;
             }
         }
     }

--- a/Runtime/Loggers/FileLoggerAsset.cs
+++ b/Runtime/Loggers/FileLoggerAsset.cs
@@ -144,7 +144,7 @@ namespace DeNA.Anjin.Loggers
         public static void ResetLoggers()
         {
             // Reset runtime instances
-            var loggerAssets = FindObjectsOfType<FileLoggerAsset>();
+            var loggerAssets = Resources.FindObjectsOfTypeAll<FileLoggerAsset>();
             foreach (var current in loggerAssets)
             {
                 current._handler?.Dispose();

--- a/Runtime/Loggers/FileLoggerAsset.cs
+++ b/Runtime/Loggers/FileLoggerAsset.cs
@@ -39,7 +39,9 @@ namespace DeNA.Anjin.Loggers
         /// </summary>
         public bool timestamp = true;
 
-        private FileLogHandler _handler;
+#pragma warning disable IDISP006
+        private FileLogHandler _handler; // Note: dispose in ResetLoggers
+#pragma warning restore IDISP006
         private ILogger _logger;
 
         /// <inheritdoc />
@@ -64,12 +66,6 @@ namespace DeNA.Anjin.Loggers
                 _logger = new Logger(_handler) { filterLogType = filterLogType };
                 return _logger;
             }
-        }
-
-        /// <inheritdoc />
-        public override void Dispose()
-        {
-            _handler?.Dispose();
         }
 
         private class TimestampCache

--- a/Tests/Runtime/Loggers/CompositeLoggerAssetTest.cs
+++ b/Tests/Runtime/Loggers/CompositeLoggerAssetTest.cs
@@ -113,52 +113,5 @@ namespace DeNA.Anjin.Loggers
 
             Assert.That(logger2.Logs, Does.Contain((LogType.Exception, exception.ToString())));
         }
-
-        [Test]
-        public void Dispose_CompositeMultipleLoggers_DisposeAllLoggers()
-        {
-            var logger1 = ScriptableObject.CreateInstance<SpyLoggerAsset>();
-            var logger2 = ScriptableObject.CreateInstance<SpyLoggerAsset>();
-            var sut = ScriptableObject.CreateInstance<CompositeLoggerAsset>();
-            sut.loggerAssets.Add(logger1);
-            sut.loggerAssets.Add(logger2);
-
-            var message = TestContext.CurrentContext.Test.Name;
-            sut.Logger.Log(message);
-            sut.Dispose();
-
-            Assert.That(logger1.Disposed, Is.True);
-            Assert.That(logger2.Disposed, Is.True);
-        }
-
-        [Test]
-        public void Dispose_LoggersIncludesNull_IgnoreNull()
-        {
-            var logger2 = ScriptableObject.CreateInstance<SpyLoggerAsset>();
-            var sut = ScriptableObject.CreateInstance<CompositeLoggerAsset>();
-            sut.loggerAssets.Add(null);
-            sut.loggerAssets.Add(logger2);
-
-            var message = TestContext.CurrentContext.Test.Name;
-            sut.Logger.Log(message);
-            sut.Dispose();
-
-            Assert.That(logger2.Disposed, Is.True);
-        }
-
-        [Test]
-        public void Dispose_NestingLogger_IgnoreNested()
-        {
-            var logger2 = ScriptableObject.CreateInstance<SpyLoggerAsset>();
-            var sut = ScriptableObject.CreateInstance<CompositeLoggerAsset>();
-            sut.loggerAssets.Add(sut); // nesting
-            sut.loggerAssets.Add(logger2);
-
-            var message = TestContext.CurrentContext.Test.Name;
-            sut.Logger.Log(message);
-            sut.Dispose();
-
-            Assert.That(logger2.Disposed, Is.True);
-        }
     }
 }

--- a/Tests/Runtime/Loggers/ConsoleLoggerAssetTest.cs
+++ b/Tests/Runtime/Loggers/ConsoleLoggerAssetTest.cs
@@ -4,9 +4,6 @@
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 
 namespace DeNA.Anjin.Loggers
 {
@@ -39,23 +36,6 @@ namespace DeNA.Anjin.Loggers
 
             LogAssert.Expect(logType, message);
             LogAssert.NoUnexpectedReceived();
-        }
-
-        [Test]
-        public void ResetLoggers_ResetLoggerAsset()
-        {
-            var sut = ScriptableObject.CreateInstance<ConsoleLoggerAsset>();
-            sut.filterLogType = LogType.Warning;
-            sut.Logger.Log("Before reset");
-            sut.Dispose();
-            Assume.That(sut.Logger.filterLogType, Is.EqualTo(LogType.Warning));
-
-            ConsoleLoggerAsset.ResetLoggers(); // Called when on launch autopilot
-
-            sut.filterLogType = LogType.Error;
-            sut.Logger.Log("After reset");
-            sut.Dispose();
-            Assert.That(sut.Logger.filterLogType, Is.EqualTo(LogType.Error));
         }
     }
 }

--- a/Tests/Runtime/Loggers/FileLoggerAssetTest.cs
+++ b/Tests/Runtime/Loggers/FileLoggerAssetTest.cs
@@ -66,7 +66,6 @@ namespace DeNA.Anjin.Loggers
             sut.timestamp = false;
 
             sut.Logger.Log(message);
-            sut.Dispose();
             await Task.Yield();
 
             var actual = File.ReadAllText(path);
@@ -85,7 +84,6 @@ namespace DeNA.Anjin.Loggers
             sut.timestamp = false;
 
             sut.Logger.Log(message);
-            sut.Dispose();
             await Task.Yield();
 
             var actual = File.ReadAllText(path);
@@ -114,7 +112,6 @@ namespace DeNA.Anjin.Loggers
             sut.timestamp = false;
 
             sut.Logger.Log(message);
-            sut.Dispose();
             await Task.Yield();
 
             var actual = File.ReadAllText(path);
@@ -135,28 +132,6 @@ namespace DeNA.Anjin.Loggers
 
             sut.Logger.Log(message);
             sut.Logger.Log(message);
-            sut.Dispose();
-            await Task.Yield();
-
-            var actual = File.ReadAllText(path);
-            Assert.That(actual, Is.EqualTo(message + Environment.NewLine + message + Environment.NewLine));
-        }
-
-        [Test]
-        public async Task LogFormat_Disposed_NotWriteToFile()
-        {
-            var message = TestContext.CurrentContext.Test.Name;
-            var path = LogFilePath;
-            var sut = ScriptableObject.CreateInstance<FileLoggerAsset>();
-            sut.outputPath = path;
-            sut.timestamp = false;
-
-            sut.Logger.Log(message);
-            sut.Logger.Log(message);
-            sut.Dispose();
-            await Task.Yield();
-
-            sut.Logger.Log(message); // write after disposed
             await Task.Yield();
 
             var actual = File.ReadAllText(path);
@@ -176,7 +151,6 @@ namespace DeNA.Anjin.Loggers
             await UniTask.NextFrame();
             sut.Logger.Log(message);
             sut.Logger.Log(message); // using cache
-            sut.Dispose();
             await Task.Yield();
 
             var actual = File.ReadAllText(path);
@@ -199,28 +173,6 @@ namespace DeNA.Anjin.Loggers
 
             var exception = CreateExceptionWithStacktrace(message);
             sut.Logger.LogException(exception);
-            sut.Dispose();
-            await Task.Yield();
-
-            var actual = File.ReadAllText(path);
-            Assert.That(actual, Is.EqualTo(exception + Environment.NewLine));
-        }
-
-        [Test]
-        public async Task LogException_Disposed_NotWriteToFile()
-        {
-            var message = TestContext.CurrentContext.Test.Name;
-            var path = LogFilePath;
-            var sut = ScriptableObject.CreateInstance<FileLoggerAsset>();
-            sut.outputPath = path;
-            sut.timestamp = false;
-
-            var exception = CreateExceptionWithStacktrace(message);
-            sut.Logger.LogException(exception);
-            sut.Dispose();
-            await Task.Yield();
-
-            sut.Logger.LogException(exception); // write after disposed
             await Task.Yield();
 
             var actual = File.ReadAllText(path);
@@ -238,7 +190,6 @@ namespace DeNA.Anjin.Loggers
 
             var exception = CreateExceptionWithStacktrace(message);
             sut.Logger.LogException(exception);
-            sut.Dispose();
             await Task.Yield();
 
             var actual = File.ReadAllText(path);
@@ -246,23 +197,23 @@ namespace DeNA.Anjin.Loggers
         }
 
         [Test]
-        public async Task ResetLoggers_ResetLoggerAsset()
+        public async Task ResetLoggers_ResetLogHandler()
         {
             var path = LogFilePath;
             var sut = ScriptableObject.CreateInstance<FileLoggerAsset>();
             sut.outputPath = path;
+            sut.timestamp = false;
             sut.Logger.Log("Before reset");
-            sut.Dispose();
             await Task.Yield();
             Assume.That(path, Does.Exist);
 
-            File.Delete(path);
             FileLoggerAsset.ResetLoggers(); // Called when on launch autopilot
 
             sut.Logger.Log("After reset");
-            sut.Dispose();
             await Task.Yield();
-            Assert.That(path, Does.Exist);
+
+            var actual = File.ReadAllText(path);
+            Assert.That(actual, Is.EqualTo("After reset" + Environment.NewLine));
         }
     }
 }

--- a/Tests/Runtime/TestDoubles/SpyLoggerAsset.cs
+++ b/Tests/Runtime/TestDoubles/SpyLoggerAsset.cs
@@ -11,8 +11,6 @@ namespace DeNA.Anjin.TestDoubles
 {
     public class SpyLoggerAsset : AbstractLoggerAsset
     {
-        public bool Disposed { get; private set; }
-
         private SpyLogHandler _handler;
         private ILogger _logger;
 
@@ -32,11 +30,6 @@ namespace DeNA.Anjin.TestDoubles
         }
 
         public List<(LogType logType, string message)> Logs => _handler.Logs;
-
-        public override void Dispose()
-        {
-            Disposed = true;
-        }
 
         private class SpyLogHandler : ILogHandler
         {


### PR DESCRIPTION
### Problem

FileLogger doesn't work when Autopilot is stopped and re-run.

### Fixes

- Remove IDisposable from AbstractLoggerAsset
- Fix to find logger instance when reset logger

### Priority

I hope to your review && merge && release v1.8 in this week.
refs #100 

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).