### PR TITLE
Add EditorBrowsable(Never) attribute onto fields do not want to use

### DIFF
--- a/Runtime/Agents/TerminateAgent.cs
+++ b/Runtime/Agents/TerminateAgent.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-2024 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Cysharp.Threading.Tasks;
@@ -42,6 +43,10 @@ namespace DeNA.Anjin.Agents
         /// Exit Code when terminated by this Agent.
         /// When using it from within code, use the <code>ExitCode</code> property.
         /// </summary>
+        /// <remarks>
+        /// I want to deny access (e.g., internal accessor), but it is inconvenient for testing, so still public.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ExitCodeByTerminateAgent exitCode = ExitCodeByTerminateAgent.Normally;
 
         /// <summary>

--- a/Runtime/Settings/AutopilotSettings.cs
+++ b/Runtime/Settings/AutopilotSettings.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -80,6 +81,10 @@ namespace DeNA.Anjin.Settings
         /// Custom name of this setting used by Reporter.
         /// When using it from within code, use the <code>Name</code> property.
         /// </summary>
+        /// <remarks>
+        /// I want to deny access (e.g., internal accessor), but it is inconvenient for testing, so still public.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public new string name;
 
         /// <summary>
@@ -121,6 +126,10 @@ namespace DeNA.Anjin.Settings
         /// Autopilot exit code options when lifespan expired.
         /// When using it from within code, use the <code>ExitCode</code> property.
         /// </summary>
+        /// <remarks>
+        /// I want to deny access (e.g., internal accessor), but it is inconvenient for testing, so still public.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ExitCodeWhenLifespanExpired exitCode = ExitCodeWhenLifespanExpired.Normally;
 
         /// <summary>
@@ -168,6 +177,10 @@ namespace DeNA.Anjin.Settings
         /// This item can be overridden by the command line argument "-OUTPUT_ROOT_DIRECTORY_PATH".
         /// When using it from within code, use the <code>OutputRootPath</code> property.
         /// </summary>
+        /// <remarks>
+        /// I want to deny access (e.g., internal accessor), but it is inconvenient for testing, so still public.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string outputRootPath = "Logs";
 
         /// <summary>
@@ -185,6 +198,10 @@ namespace DeNA.Anjin.Settings
         /// This item can be overridden by the command line argument "-SCREENSHOTS_DIRECTORY_PATH".
         /// When using it from within code, use the <code>ScreenshotsPath</code> property.
         /// </summary>
+        /// <remarks>
+        /// I want to deny access (e.g., internal accessor), but it is inconvenient for testing, so still public.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string screenshotsPath = "Screenshots";
 
         /// <summary>


### PR DESCRIPTION
### Changes

Add EditorBrowsable(Never) attribute onto fields do not want to use.
I want to deny access (e.g., internal accessor), but it is inconvenient for testing, so still public.

Note: EditorBrowsable(Never) is not respected on the default preferences of JetBrains Rider.
see: https://youtrack.jetbrains.com/issue/RIDER-17669/Respect-EditorBrowsableEditorBrowsableState.Never

### Priority

Very low

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).