### PR TITLE
Fix outputRootPath when outputRootPath is null and on player

### DIFF
--- a/Runtime/Utilities/PathUtils.cs
+++ b/Runtime/Utilities/PathUtils.cs
@@ -17,6 +17,11 @@ namespace DeNA.Anjin.Utilities
         /// <returns>Absolute path.</returns>
         public static string GetAbsolutePath(string path, string basePath)
         {
+            if (string.IsNullOrEmpty(path))
+            {
+                return basePath;
+            }
+
 #if UNITY_2021_2_OR_NEWER
             if (Path.IsPathFullyQualified(path))
             {

--- a/Tests/Runtime/Settings/AutopilotSettingsTest.cs
+++ b/Tests/Runtime/Settings/AutopilotSettingsTest.cs
@@ -8,6 +8,7 @@ using DeNA.Anjin.Reporters;
 using DeNA.Anjin.TestDoubles;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace DeNA.Anjin.Settings
 {
@@ -65,6 +66,56 @@ namespace DeNA.Anjin.Settings
             settings.customExitCode = "not valid";
 
             Assert.That(settings.ExitCode, Is.EqualTo((ExitCode)ExitCodeWhenLifespanExpired.Custom));
+        }
+
+        [Test]
+        public void OutputDataPath_AbsolutePath_ReturnsAbsolutePath()
+        {
+            var settings = CreateAutopilotSettings();
+            settings.outputRootPath = "/OutputRootPath";
+
+            Assert.That(settings.OutputRootPath, Is.EqualTo("/OutputRootPath"));
+        }
+
+        [Test]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+        public void OutputDataPath_RelativePathInEditor_ReturnsAbsolutePathBasedOnProjectRoot()
+        {
+            var settings = CreateAutopilotSettings();
+            settings.outputRootPath = "OutputRootPath";
+
+            Assert.That(settings.OutputRootPath, Is.EqualTo(Path.GetFullPath("OutputRootPath")));
+        }
+
+        [Test]
+        [UnityPlatform(RuntimePlatform.OSXPlayer, RuntimePlatform.WindowsPlayer, RuntimePlatform.LinuxPlayer)]
+        public void OutputDataPath_RelativePathOnPlayer_ReturnsAbsolutePathBasedOnPersistentDataPath()
+        {
+            var settings = CreateAutopilotSettings();
+            settings.outputRootPath = "OutputRootPath";
+
+            Assert.That(settings.OutputRootPath,
+                Is.EqualTo(Path.Combine(Application.persistentDataPath, "OutputRootPath")));
+        }
+
+        [Test]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.LinuxEditor)]
+        public void OutputDataPath_NullInEditor_ReturnsProjectRootPath()
+        {
+            var settings = CreateAutopilotSettings();
+            settings.outputRootPath = null;
+
+            Assert.That(settings.OutputRootPath, Is.EqualTo(Path.GetFullPath(".")));
+        }
+
+        [Test]
+        [UnityPlatform(RuntimePlatform.OSXPlayer, RuntimePlatform.WindowsPlayer, RuntimePlatform.LinuxPlayer)]
+        public void OutputDataPath_NullOnPlayer_ReturnsPersistentDataPath()
+        {
+            var settings = CreateAutopilotSettings();
+            settings.outputRootPath = null;
+
+            Assert.That(settings.OutputRootPath, Is.EqualTo(Application.persistentDataPath));
         }
 
         [Test]

--- a/Tests/Runtime/Utilities/PathUtilsTest.cs
+++ b/Tests/Runtime/Utilities/PathUtilsTest.cs
@@ -49,6 +49,18 @@ namespace DeNA.Anjin.Utilities
         }
 
         [Test]
+        [UnityPlatform(RuntimePlatform.OSXEditor, RuntimePlatform.OSXPlayer, RuntimePlatform.LinuxEditor,
+            RuntimePlatform.LinuxPlayer)]
+        public void GetAbsolutePath_Null_ReturnsBasePath()
+        {
+            const string Path = null;
+            const string BasePath = "/Base/Path";
+
+            var actual = PathUtils.GetAbsolutePath(Path, BasePath);
+            Assert.That(actual, Is.EqualTo(BasePath));
+        }
+
+        [Test]
         [UnityPlatform(RuntimePlatform.WindowsEditor, RuntimePlatform.WindowsPlayer)]
         public void GetAbsolutePath_WindowsAbsolutePath_ReturnsPath()
         {


### PR DESCRIPTION
### Fixes

- Fix `OutputRootPath` when `outputRootPath` is null and on player
- Add tests

### Priority

Low

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).