### PR TITLE
Fix compilation warnings

### DIFF
--- a/Runtime/AgentInspector.cs
+++ b/Runtime/AgentInspector.cs
@@ -18,6 +18,11 @@ namespace DeNA.Anjin
         /// Returns the running Agent instance array.
         /// No caching.
         /// </summary>
+#if UNITY_2022_3_OR_NEWER
+        public static AgentInspector[] Instances => FindObjectsByType<AgentInspector>(FindObjectsSortMode.None);
+        // Note: Supported in Unity 2020.3.4, 2021.3.18, 2022.2.5 or later.
+#else
         public static AgentInspector[] Instances => FindObjectsOfType<AgentInspector>();
+#endif
     }
 }

--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -55,7 +55,12 @@ namespace DeNA.Anjin
         {
             get
             {
+#if UNITY_2022_3_OR_NEWER
+                var autopilot = FindAnyObjectByType<Autopilot>();
+                // Note: Supported in Unity 2020.3.4, 2021.3.18, 2022.2.5 or later.
+#else
                 var autopilot = FindObjectOfType<Autopilot>();
+#endif
                 if (autopilot == null)
                 {
                     throw new InvalidOperationException("Autopilot instance not found");

--- a/Tests/Runtime/Agents/UGUIPlaybackAgentTest.cs
+++ b/Tests/Runtime/Agents/UGUIPlaybackAgentTest.cs
@@ -116,7 +116,6 @@ namespace DeNA.Anjin.Agents
 #endif
             agent.Logger = Debug.unityLogger;
             agent.Random = new RandomFactory(0).CreateRandom();
-            agent.name = TestContext.CurrentContext.Test.Name;
 
             using (var cancellationTokenSource = new CancellationTokenSource())
             {

--- a/Tests/TestAssets/PlaybackAgent.asset
+++ b/Tests/TestAssets/PlaybackAgent.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d429d6926ea8c4f688c2bfed7e53d7cf, type: 3}
-  m_Name: Run_WithAssetFile
+  m_Name: PlaybackAgent
   m_EditorClassIdentifier: 
   description: 
   recordedJson: {fileID: 4900000, guid: 7847549ddc204e628dbc7746afd8f03f, type: 3}


### PR DESCRIPTION
### Fixes

- Use FindObject(s)ByType in Unity 2022.3 or newer
- Fix test asset name

### Priority

Very low

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).