### PR TITLE
Fix behavior after Autopilot failure in Play Mode tests

### DIFF
--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -22,7 +22,7 @@ namespace DeNA.Anjin
     public interface ITerminatable
     {
         /// <summary>
-        /// Terminate autopilot
+        /// Terminate Autopilot
         /// </summary>
         /// <param name="exitCode">Exit code for Unity Editor/ Player-build</param>
         /// <param name="message">Log message string or terminate message</param>
@@ -92,6 +92,7 @@ namespace DeNA.Anjin
 
             _logger = _settings.LoggerAsset.Logger;
             // Note: Set a default logger if no logger settings. see: AutopilotSettings.Initialize method.
+            _logger.Log("Launching Autopilot…");
 
             if (!int.TryParse(_settings.randomSeed, out var seed))
             {
@@ -122,7 +123,7 @@ namespace DeNA.Anjin
                 Time.timeScale = _settings.timeScale;
             }
 
-            _logger.Log("Launched autopilot");
+            _logger.Log("Launched Autopilot");
         }
 
         private void DispatchByLoadedScenes()
@@ -192,7 +193,7 @@ namespace DeNA.Anjin
 
 #if UNITY_EDITOR
         /// <summary>
-        /// Stop autopilot on play mode exit event when run on Unity editor.
+        /// Stop Autopilot on play mode exit event when run on Unity editor.
         /// Not called when invoked from play mode (not registered in event listener).
         /// </summary>
         private static void OnExitPlayModeToTerminateEditor(PlayModeStateChange playModeStateChange)

--- a/Runtime/Autopilot.cs
+++ b/Runtime/Autopilot.cs
@@ -181,7 +181,7 @@ namespace DeNA.Anjin
             Destroy(this.gameObject);
 
             _logger.Log("Terminate Autopilot");
-            Launcher.TeardownLaunchAutopilotAsync(_state, _logger, exitCode, "Autopilot").Forget();
+            Launcher.TeardownLaunchAutopilotAsync(_state, _logger, exitCode, message).Forget();
         }
 
         [Obsolete("Use " + nameof(TerminateAsync))]

--- a/Runtime/Launcher.cs
+++ b/Runtime/Launcher.cs
@@ -51,6 +51,14 @@ namespace DeNA.Anjin
             LaunchAutopilot().Forget();
 
             await UniTask.WaitUntil(() => !state.IsRunning, cancellationToken: token);
+
+#if UNITY_INCLUDE_TESTS
+            // Launch from Play Mode tests
+            if (TestContext.CurrentContext != null && state.exitCode != ExitCode.Normally)
+            {
+                throw new AssertionException($"  Autopilot run failed with exit code \"{state.exitCode}\".");
+            }
+#endif
         }
 
         /// <summary>
@@ -228,13 +236,6 @@ namespace DeNA.Anjin
 
             if (state.launchFrom == LaunchType.PlayMode) // Note: Editor play mode, Play mode tests, and Player build
             {
-#if UNITY_INCLUDE_TESTS
-                // Play mode tests
-                if (TestContext.CurrentContext != null && exitCode != ExitCode.Normally)
-                {
-                    throw new AssertionException($"{caller} failed with exit code {(int)exitCode}");
-                }
-#endif
                 return; // Only terminate autopilot run if starting from play mode.
             }
 

--- a/Runtime/Settings/AutopilotState.cs
+++ b/Runtime/Settings/AutopilotState.cs
@@ -39,6 +39,13 @@ namespace DeNA.Anjin.Settings
         public ExitCode exitCode;
 
         /// <summary>
+        /// Exit message.
+        /// </summary>
+        [HideInInspector]
+        [CanBeNull]
+        public string exitMessage;
+
+        /// <summary>
         /// Reset run state
         /// </summary>
         public void Reset()
@@ -46,6 +53,7 @@ namespace DeNA.Anjin.Settings
             launchFrom = LaunchType.NotSet;
             settings = null;
             exitCode = ExitCode.Normally;
+            exitMessage = null;
 #if UNITY_EDITOR && UNITY_2020_3_OR_NEWER
             EditorUtility.SetDirty(this);
             AssetDatabase.SaveAssetIfDirty(this); // Note: Sync with virtual players of MPPM package

--- a/Tests/Runtime/AutopilotTest.cs
+++ b/Tests/Runtime/AutopilotTest.cs
@@ -170,7 +170,7 @@ namespace DeNA.Anjin
             await Launcher.LaunchAutopilotAsync(autopilotSettings);
             await UniTask.NextFrame(); // wait flushing log for subsequence tests
 
-            LogAssert.Expect(LogType.Log, "Launched autopilot"); // using console logger
+            LogAssert.Expect(LogType.Log, "Launched Autopilot"); // using console logger
         }
 
         [Test]
@@ -183,7 +183,7 @@ namespace DeNA.Anjin
 
             await Launcher.LaunchAutopilotAsync(autopilotSettings);
 
-            Assert.That(spyLogger.Logs, Does.Contain((LogType.Log, "Launched autopilot"))); // using spy logger
+            Assert.That(spyLogger.Logs, Does.Contain((LogType.Log, "Launched Autopilot"))); // using spy logger
             LogAssert.NoUnexpectedReceived(); // not write to console
         }
 

--- a/Tests/Runtime/AutopilotTest.cs
+++ b/Tests/Runtime/AutopilotTest.cs
@@ -67,14 +67,21 @@ namespace DeNA.Anjin
             settings.customExitCode = "100";
             settings.exitMessage = "Lifespan expired";
 
-            await Launcher.LaunchAutopilotAsync(settings);
+            try
+            {
+                await Launcher.LaunchAutopilotAsync(settings);
+                Assert.Fail("No AssertionException was thrown");
+            }
+            catch (AssertionException)
+            {
+                // expected behavior
+            }
+
             await UniTask.NextFrame(); // wait reporter
 
             Assert.That(spyReporter.IsCalled, Is.True);
             Assert.That(spyReporter.Arguments["exitCode"], Is.EqualTo("100"));
             Assert.That(spyReporter.Arguments["message"], Is.EqualTo("Lifespan expired"));
-
-            LogAssert.Expect(LogType.Exception, "AssertionException: Autopilot failed with exit code 100");
         }
 
         [Test]


### PR DESCRIPTION
### Expected behavior

Throw `NUnit.Framework.AssertionException` when Autopilot fails in Play Mode tests.

### Problem

Not thrown an exception.
Output LogException in the console.

Because throwing an exception in an async method that had been `Forget`.

### Fixes

Throw exception in `LaunchAutopilotAsync` method.

### Priority

I hope to your review && merge && release this week.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).