### PR TITLE
Mod TerminateAsync return type UniTaskVoid and remove parameter CancellationToken

### DIFF
--- a/Tests/Runtime/AutopilotTest.cs
+++ b/Tests/Runtime/AutopilotTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 DeNA Co., Ltd.
+// Copyright (c) 2023-2025 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -97,7 +97,9 @@ namespace DeNA.Anjin
             var agents = AgentInspector.Instances;
             Assume.That(agents, Is.Not.Empty, "Agents are running");
 
-            await autopilot.TerminateAsync(ExitCode.Normally, reporting: false);
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            autopilot.TerminateAsync(ExitCode.Normally, reporting: false);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             await UniTask.NextFrame(); // wait for destroy
 
             autopilot = Object.FindObjectOfType<Autopilot>(); // re-find after terminated
@@ -138,7 +140,9 @@ namespace DeNA.Anjin
             await UniTask.Delay(500); // wait for launch
 
             var autopilot = Autopilot.Instance;
-            await autopilot.TerminateAsync(ExitCode.Normally, null, null, false);
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            autopilot.TerminateAsync(ExitCode.Normally, null, null, false);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
             Assert.That(spyReporter.IsCalled, Is.False);
         }
@@ -153,7 +157,9 @@ namespace DeNA.Anjin
             await UniTask.Delay(500); // wait for launch
 
             var autopilot = Autopilot.Instance;
-            await autopilot.TerminateAsync(ExitCode.Normally, "message", "stack trace", true);
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            autopilot.TerminateAsync(ExitCode.Normally, "message", "stack trace", true);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
             Assert.That(spyReporter.IsCalled, Is.True);
             Assert.That(spyReporter.Arguments["exitCode"], Is.EqualTo("Normally"));

--- a/Tests/Runtime/TestDoubles/SpyTerminatable.cs
+++ b/Tests/Runtime/TestDoubles/SpyTerminatable.cs
@@ -1,7 +1,6 @@
-// Copyright (c) 2023-2024 DeNA Co., Ltd.
+// Copyright (c) 2023-2025 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
-using System.Threading;
 using Cysharp.Threading.Tasks;
 
 namespace DeNA.Anjin.TestDoubles
@@ -14,8 +13,8 @@ namespace DeNA.Anjin.TestDoubles
         public string CapturedStackTrace { get; private set; }
         public bool CapturedReporting { get; private set; }
 
-        public async UniTask TerminateAsync(ExitCode exitCode, string message = null, string stackTrace = null,
-            bool reporting = true, CancellationToken token = default)
+        public async UniTaskVoid TerminateAsync(ExitCode exitCode, string message = null, string stackTrace = null,
+            bool reporting = true)
         {
             IsCalled = true;
             CapturedExitCode = exitCode;


### PR DESCRIPTION
### Changes

Mod `Autopilot.TerminateAsync` return type from `UniTask` to `UniTaskVoid`.
And remove parameter `CancellationToken`.

Generally, use the `TerminateAsync` method with `Forget()`.
Also, this prevents accidents such as accidentally passing a `CancellationToken` and canceling the termination.

I changed the method signature because I couldn't attach `ObsoleteAttribute` to the arguments, but since it's an internal method, I don't think I need to mark it as a "breaking changes".

### Priority

Very low


---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).