### PR TITLE
Fix to Agent is not destroyed

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ git submodule add https://github.com/dena/Anjin.git Packages/com.dena.anjin
 > [!WARNING]  
 > Required install packages for running tests (when adding to the `testables` in package.json), as follows:
 > - [Unity Test Framework](https://docs.unity3d.com/Packages/com.unity.test-framework@latest) package v1.3.4 or later
-> - [Test Helper](https://github.com/nowsprinting/test-helper) package v0.7.2 or later
+> - [Test Helper](https://github.com/nowsprinting/test-helper) package v1.1.1 or later
 
 Generate a temporary project and run tests on each Unity version from the command line.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -856,7 +856,7 @@ git submodule add https://github.com/dena/Anjin.git Packages/com.dena.anjin
 > [!WARNING]  
 > Anjinパッケージ内のテストを実行するためには、次のパッケージのインストールが必要です。
 > - [Unity Test Framework](https://docs.unity3d.com/Packages/com.unity.test-framework@latest) package v1.3.4 or later
-> - [Test Helper](https://github.com/nowsprinting/test-helper) package v0.7.2 or later
+> - [Test Helper](https://github.com/nowsprinting/test-helper) package v1.1.1 or later
 
 テスト専用のUnityプロジェクトを生成し、Unityバージョンを指定してテストを実行するには、次のコマンドを実行します。
 

--- a/Runtime/AgentDispatcher.cs
+++ b/Runtime/AgentDispatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023-2024 DeNA Co., Ltd.
+﻿// Copyright (c) 2023-2025 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
 using System;
@@ -101,7 +101,7 @@ namespace DeNA.Anjin
                 return false;
             }
 
-            DispatchAgent(agent);
+            DispatchAgent(agent, scene);
             return true;
         }
 
@@ -110,11 +110,11 @@ namespace DeNA.Anjin
         {
             _settings.sceneCrossingAgents.ForEach(agent =>
             {
-                DispatchAgent(agent, true);
+                DispatchAgent(agent, dontDestroyOnLoad: true);
             });
         }
 
-        private void DispatchAgent(AbstractAgent agent, bool dontDestroyOnLoad = false)
+        private void DispatchAgent(AbstractAgent agent, Scene scene = default, bool dontDestroyOnLoad = false)
         {
             var agentName = agent.name;
             agent.Logger = _logger;
@@ -124,6 +124,10 @@ namespace DeNA.Anjin
             if (dontDestroyOnLoad)
             {
                 Object.DontDestroyOnLoad(inspector.gameObject);
+            }
+            else if (scene != default)
+            {
+                SceneManager.MoveGameObjectToScene(inspector.gameObject, scene);
             }
 
             var token = inspector.gameObject.GetCancellationTokenOnDestroy();

--- a/Tests/Runtime/AgentDispatcherTest.cs
+++ b/Tests/Runtime/AgentDispatcherTest.cs
@@ -56,7 +56,7 @@ namespace DeNA.Anjin
         }
 
         [Test]
-        [CreateScene]
+        [CreateScene(unloadOthers: true)]
         public async Task DispatchByScene_DispatchAgentBySceneAgentMaps()
         {
             const string AgentName = "Mapped Agent";
@@ -75,7 +75,7 @@ namespace DeNA.Anjin
         }
 
         [Test]
-        [CreateScene]
+        [CreateScene(unloadOthers: true)]
         public async Task DispatchByScene_DispatchFallbackAgent()
         {
             const string AgentName = "Fallback Agent";
@@ -91,7 +91,7 @@ namespace DeNA.Anjin
         }
 
         [Test]
-        [CreateScene]
+        [CreateScene(unloadOthers: true)]
         public async Task DispatchByScene_NoSceneAgentMapsAndFallbackAgent_AgentIsNotDispatch()
         {
             var settings = ScriptableObject.CreateInstance<AutopilotSettings>();
@@ -104,7 +104,7 @@ namespace DeNA.Anjin
         }
 
         [Test]
-        [CreateScene]
+        [CreateScene(unloadOthers: true)]
         public async Task DispatchByScene_ReActivateScene_NotCreateDuplicateAgents()
         {
             const string AgentName = "Mapped Agent";
@@ -150,7 +150,7 @@ namespace DeNA.Anjin
         }
 
         [Test]
-        [CreateScene]
+        [CreateScene(unloadOthers: true)]
         public void DispatchSceneCrossingAgents_DispatchAgent()
         {
             const string AgentName = "Scene Crossing Agent";
@@ -166,6 +166,7 @@ namespace DeNA.Anjin
         }
 
         [Test]
+        [CreateScene(unloadOthers: true)]
         public async Task Dispose_DestroyAllRunningAgents()
         {
             var settings = ScriptableObject.CreateInstance<AutopilotSettings>();


### PR DESCRIPTION
### Problem

Agent is not destroyed if the following sequence:

1. Mapped scene is additive-loaded (not activated)
2. Other scenes are additive-loaded (not unload mapped-scene because they are not single-loaded)
3. Unload mapped scene

See test case DispatchByScene_SceneUnloadWithoutBecomingActive_DisposeAgent in Tests/Runtime/AgentDispatcherTest.cs

### Fixes

`AgentInspector` object moves to mapped scene.

### Other changes

- Upgrade tests required test-helper package version to v1.1.1
    - Using unloadOthers option in CreateSceneAttribute

### Priority

I hope to your review && merge && release it in around one week.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).