### PR TITLE
Upgrade tests required com.unity.test-framewor to v1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,7 +845,7 @@ git submodule add https://github.com/dena/Anjin.git Packages/com.dena.anjin
 
 > [!WARNING]  
 > Required install packages for running tests (when adding to the `testables` in package.json), as follows:
-> - [Unity Test Framework](https://docs.unity3d.com/Packages/com.unity.test-framework@latest) package v1.3.4 or later
+> - [Unity Test Framework](https://docs.unity3d.com/Packages/com.unity.test-framework@latest) package v1.4.1 or later
 > - [Test Helper](https://github.com/nowsprinting/test-helper) package v1.1.1 or later
 
 Generate a temporary project and run tests on each Unity version from the command line.

--- a/README_ja.md
+++ b/README_ja.md
@@ -855,7 +855,7 @@ git submodule add https://github.com/dena/Anjin.git Packages/com.dena.anjin
 
 > [!WARNING]  
 > Anjinパッケージ内のテストを実行するためには、次のパッケージのインストールが必要です。
-> - [Unity Test Framework](https://docs.unity3d.com/Packages/com.unity.test-framework@latest) package v1.3.4 or later
+> - [Unity Test Framework](https://docs.unity3d.com/Packages/com.unity.test-framework@latest) package v1.4.1 or later
 > - [Test Helper](https://github.com/nowsprinting/test-helper) package v1.1.1 or later
 
 テスト専用のUnityプロジェクトを生成し、Unityバージョンを指定してテストを実行するには、次のコマンドを実行します。


### PR DESCRIPTION
### Problem

Fail two tests in ErrorHandlerAgentTest with com.unity.test-framework package v1.4.0 or older.

### Fixes

Upgrade required com.unity.test-framework package version to v1.4.1

> In async tests, any failing logs will now first be evaluated after the async method has completed. (DSTR-839)

see: https://docs.unity3d.com/Packages/com.unity.test-framework@1.4/changelog/CHANGELOG.html#141---2023-11-13

### Priority

Very low

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).