### PR TITLE
Fix coverage option run on command-line

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,7 +2,7 @@
 coverage:
   if: true
   paths:
-    - ./Logs/Report/lcov.info # Warning: This path is replace by regex in test.yml
+    - UnityProject~/Logs/Report/lcov.info # Warning: This path is to be replaced by regex in test.yml
 
 codeToTestRatio:
   code:

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ define cover
   $(UNITY) \
     $(call base_arguments) \
     $(call test_arguments) \
-    -burst-disable-compilation \
+    --burst-disable-compilation \
     -debugCodeOptimization \
     -enableCodeCoverage \
     -coverageResultsPath $(LOG_DIR) \


### PR DESCRIPTION
### Fixes

- Fix commandline argument `--burst-disable-compilation` is to be passed with two dashes
- Fix lcov.info path

### Priority

Very low

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).