### PR TITLE
Fix to Slack channel can be specified channel name

### DIFF
--- a/Editor/Localization/ja.po
+++ b/Editor/Localization/ja.po
@@ -568,8 +568,8 @@ msgid "Slack Channels"
 msgstr "Slackチャンネル"
 
 # slackChannels tooltip
-msgid "Comma-separated Slack channel's IDs (e.g., \"C123456\") to post. If omitted, it will not be sent."
-msgstr "Slack通知を送るチャンネルID（例: \"C123456\"）をカンマ区切りで指定します。省略時は送信されません"
+msgid "Comma-separated Slack channel name (e.g., \"#test\") or ID (e.g., \"C123456\") to post. If omitted, it will not be sent."
+msgstr "Slack通知を送るチャンネルの名前（例: \"#test\"）またはID（例: \"C123456\"）をカンマ区切りで指定します。省略時は送信されません"
 
 # Header: Error Report Settings
 msgid "Error Report Settings"

--- a/Editor/UI/Reporters/SlackReporterEditor.cs
+++ b/Editor/UI/Reporters/SlackReporterEditor.cs
@@ -29,7 +29,7 @@ namespace DeNA.Anjin.Editor.UI.Reporters
         private GUIContent _slackTokenGUIContent;
 
         private static readonly string s_slackChannels = L10n.Tr("Slack Channels");
-        private static readonly string s_slackChannelsTooltip = L10n.Tr("Comma-separated Slack channel's IDs (e.g., \"C123456\") to post. If omitted, it will not be sent.");
+        private static readonly string s_slackChannelsTooltip = L10n.Tr("Comma-separated Slack channel name (e.g., \"#test\") or ID (e.g., \"C123456\") to post. If omitted, it will not be sent.");
         private SerializedProperty _slackChannelsProp;
         private GUIContent _slackChannelsGUIContent;
 

--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ The instance of this Reporter (.asset file) can have the following settings.
 <dl>
   <dt>Slack Token</dt><dd>Slack Bot OAuth token. If omitted, it will not be sent.
         It can be overwritten with the command line argument <code>-SLACK_TOKEN</code>, but be careful if multiple SlackReporters are defined, they will all be overwritten with the same value.</dd>
-  <dt>Slack Channels</dt><dd>Comma-separated Slack channel's IDs (e.g., "C123456") to post. If omitted, it will not be sent.
+  <dt>Slack Channels</dt><dd>Comma-separated Slack channel name (e.g., "#test") or ID (e.g., "C123456") to post. If omitted, it will not be sent.
         Note that the bot must be invited to the channel.
         It can be overwritten with the command line argument <code>-SLACK_CHANNELS</code>, but be careful if multiple SlackReporters are defined, they will all be overwritten with the same value.</dd>
   <dt>Mention User Group IDs</dt><dd>Comma-separated user group IDs to mention when posting error reports.</dd>
@@ -806,11 +806,6 @@ Now, automatically converted it to SlackReporter asset file. Check it out and co
 
 This message that the obsolete setting item has been automatically converted to the new setting method (`SlackReporter` in the above example).
 The settings file has been updated, so please check it out and commit it to your VCS (e.g., Git).
-
-
-### Screenshot was not posted to Slack
-
-Since Anjin v1.8.3 or newer, please specify the channel ID (e.g., "C123456") instead of the channel name (e.g., "#channel") in `SlackReporter`.
 
 
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -519,7 +519,7 @@ Slackにレポート送信するReporterです。
 <dl>
   <dt>Slackトークン</dt><dd>Slack通知に使用するBotのOAuthトークン。省略時は送信されません。
         コマンドライン引数 <code>-SLACK_TOKEN</code> で上書きできますが、複数のSlackReporterを定義しているとき、すべて同じ値で上書きされますので注意してください。</dd>
-  <dt>Slackチャンネル</dt><dd>Slack通知を送るチャンネルID（例: \"C123456\"）をカンマ区切りで指定します。省略時は送信されません。
+  <dt>Slackチャンネル</dt><dd>Slack通知を送るチャンネルの名前（例: "#test"）またはID（例: "C123456"）をカンマ区切りで指定します。省略時は送信されません。
         チャンネルにはBotを招待しておく必要があります。
         コマンドライン引数 <code>-SLACK_CHANNELS</code> で上書きできますが、複数のSlackReporterを定義しているとき、すべて同じ値で上書きされますので注意してください。</dd>
   <dt>メンション宛先ユーザーグループID</dt><dd>エラー終了時に送信する通知をメンションするユーザーグループのIDをカンマ区切りで指定します</dd>
@@ -815,11 +815,6 @@ Now, automatically converted it to SlackReporter asset file. Check it out and co
 
 これは、廃止された設定項目を新しい設定方法（上例では `SlackReporter` ）に自動変換したことを示しています。
 設定ファイルが更新されていますので、確認してVCS（Gitなど）にコミットしてください。
-
-
-### スクリーンショットがSlackに投稿されない
-
-Anjin v1.8.3 以降、`SlackReporter`にはチャンネル名（例: "#channel"）ではなくチャンネルID（例: "C123456"）を指定してください。
 
 
 

--- a/Runtime/Reporters/Slack/Response/SlackResponse.cs
+++ b/Runtime/Reporters/Slack/Response/SlackResponse.cs
@@ -31,7 +31,12 @@ namespace DeNA.Anjin.Reporters.Slack.Response
         public string warning;
 
         /// <summary>
-        /// Thread timestamp.
+        /// Channel ID.
+        /// </summary>
+        public string channel;
+
+        /// <summary>
+        /// Thread timestamp ID.
         /// </summary>
         public string ts;
 
@@ -65,12 +70,12 @@ namespace DeNA.Anjin.Reporters.Slack.Response
             }
 #endif
 
-            if (parseBody)
+            if (!parseBody)
             {
-                return FromJson(www.downloadHandler.text);
+                return new SlackResponse() { ok = true };
             }
 
-            return new SlackResponse() { ok = true };
+            return FromJson(www.downloadHandler.text);
         }
 
         public static SlackResponse FromJson(string json)

--- a/Runtime/Reporters/Slack/SlackAPI.cs
+++ b/Runtime/Reporters/Slack/SlackAPI.cs
@@ -21,7 +21,7 @@ namespace DeNA.Anjin.Reporters.Slack
         /// Post text message
         /// </summary>
         /// <param name="token">Slack token</param>
-        /// <param name="channel">Send target channels</param>
+        /// <param name="channel">Send target channel ID or name</param>
         /// <param name="text">Lead text (out of attachment)</param>
         /// <param name="message">Message body text (into attachment)</param>
         /// <param name="color">Attachment color</param>
@@ -58,7 +58,7 @@ namespace DeNA.Anjin.Reporters.Slack
         /// Without attachments.
         /// </summary>
         /// <param name="token">Slack token</param>
-        /// <param name="channel">Send target channels</param>
+        /// <param name="channel">Send target channel ID or name</param>
         /// <param name="text">Text (out of attachment)</param>
         /// <param name="ts">Thread timestamp</param>
         /// <returns></returns>
@@ -81,11 +81,11 @@ namespace DeNA.Anjin.Reporters.Slack
         /// Post image
         /// </summary>
         /// <param name="token">Slack token</param>
-        /// <param name="channel">Send target channels</param>
+        /// <param name="channelId">Send target channel ID (Not allow name)</param>
         /// <param name="image">Image (screenshot)</param>
         /// <param name="ts">Thread timestamp</param>
         /// <returns></returns>
-        public virtual async UniTask<SlackResponse> Post(string token, string channel, byte[] image,
+        public virtual async UniTask<SlackResponse> Post(string token, string channelId, byte[] image,
             string ts = null)
         {
             const string Filename = "screenshot.png";
@@ -102,7 +102,7 @@ namespace DeNA.Anjin.Reporters.Slack
                 return uploadResponse;
             }
 
-            return await CompleteUploadExternal(token, uploadURLExternalResponse.file_id, channel, ts);
+            return await CompleteUploadExternal(token, uploadURLExternalResponse.file_id, channelId, ts);
         }
 
         private static async UniTask<SlackResponse> Post(string url, string token, Payload payload)

--- a/Runtime/Reporters/Slack/SlackAPI.cs
+++ b/Runtime/Reporters/Slack/SlackAPI.cs
@@ -21,7 +21,7 @@ namespace DeNA.Anjin.Reporters.Slack
         /// Post text message
         /// </summary>
         /// <param name="token">Slack token</param>
-        /// <param name="channel">Send target channel ID or name</param>
+        /// <param name="channel">Slack channel ID or name to post</param>
         /// <param name="text">Lead text (out of attachment)</param>
         /// <param name="message">Message body text (into attachment)</param>
         /// <param name="color">Attachment color</param>
@@ -58,7 +58,7 @@ namespace DeNA.Anjin.Reporters.Slack
         /// Without attachments.
         /// </summary>
         /// <param name="token">Slack token</param>
-        /// <param name="channel">Send target channel ID or name</param>
+        /// <param name="channel">Slack channel ID or name to post</param>
         /// <param name="text">Text (out of attachment)</param>
         /// <param name="ts">Thread timestamp</param>
         /// <returns></returns>
@@ -81,7 +81,7 @@ namespace DeNA.Anjin.Reporters.Slack
         /// Post image
         /// </summary>
         /// <param name="token">Slack token</param>
-        /// <param name="channelId">Send target channel ID (Not allow name)</param>
+        /// <param name="channelId">Slack channel ID to post (a channel name is not allowed)</param>
         /// <param name="image">Image (screenshot)</param>
         /// <param name="ts">Thread timestamp</param>
         /// <returns></returns>

--- a/Runtime/Reporters/Slack/SlackMessageSender.cs
+++ b/Runtime/Reporters/Slack/SlackMessageSender.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 DeNA Co., Ltd.
+// Copyright (c) 2023-2025 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -112,7 +112,7 @@ namespace DeNA.Anjin.Reporters.Slack
 
                 await _slackAPI.Post(
                     slackToken,
-                    slackChannel,
+                    postTitleTask.channel,
                     withoutAlpha.EncodeToPNG(),
                     postTitleTask.ts
                 );
@@ -124,7 +124,6 @@ namespace DeNA.Anjin.Reporters.Slack
                 await _slackAPI.PostWithoutAttachments(slackToken, slackChannel, stackTrace, postTitleTask.ts);
             }
         }
-
 
         private static string CreateLead(string lead, IEnumerable<string> mentionSubTeamIDs, bool withHere)
         {

--- a/Runtime/Reporters/Slack/SlackMessageSender.cs
+++ b/Runtime/Reporters/Slack/SlackMessageSender.cs
@@ -11,8 +11,8 @@ namespace DeNA.Anjin.Reporters.Slack
 {
     /// <summary>
     /// An interface for Slack message senders. The derived class of this interface must define message format, and
-    /// delegate touching Slack API to <c cref="SlackAPI" />.
-    /// Purpose of introducing this interface is making <c cref="SlackReporter" /> be a humble object.
+    /// delegate touching Slack API to <c cref="SlackAPI">SlackAPI</c>.
+    /// Purpose of introducing this interface is making <c cref="SlackReporter">SlackReporter</c> be a humble object.
     /// </summary>
     public interface ISlackMessageSender
     {
@@ -20,8 +20,8 @@ namespace DeNA.Anjin.Reporters.Slack
         /// Post report log message, stacktrace and screenshot
         /// </summary>
         /// <param name="slackToken">Slack API token</param>
-        /// <param name="slackChannel">Slack Channel to send notification</param>
-        /// <param name="mentionSubTeamIDs">Sub team IDs to mention</param>
+        /// <param name="slackChannel">Slack channel ID or name to send notification</param>
+        /// <param name="mentionSubTeamIDs">Subteam IDs to mention</param>
         /// <param name="addHereInSlackMessage">Whether adding @here or not</param>
         /// <param name="lead">Lead text (out of attachment)</param>
         /// <param name="message">Message body text (into attachment)</param>
@@ -46,23 +46,21 @@ namespace DeNA.Anjin.Reporters.Slack
 
     /// <summary>
     /// A class for Slack message senders. This class defines a message format and delegates touching Slack API to
-    /// <c cref="SlackAPI" />.
+    /// <c cref="SlackAPI">SlackAPI</c>.
     /// </summary>
     public class SlackMessageSender : ISlackMessageSender
     {
         private readonly SlackAPI _slackAPI;
         private readonly string _slackToken;
 
-
         /// <summary>
-        /// Creates a new instance for <c cref="SlackMessageSender" />.
+        /// Creates a new instance for <c cref="SlackMessageSender">SlackMessageSender</c>.
         /// </summary>
         /// <param name="api">Slack API client</param>
         public SlackMessageSender(SlackAPI api)
         {
             _slackAPI = api;
         }
-
 
         /// <inheritdoc />
         public async UniTask Send(
@@ -112,7 +110,7 @@ namespace DeNA.Anjin.Reporters.Slack
 
                 await _slackAPI.Post(
                     slackToken,
-                    postTitleTask.channel,
+                    postTitleTask.channel, // channel ID
                     withoutAlpha.EncodeToPNG(),
                     postTitleTask.ts
                 );

--- a/Runtime/Reporters/Slack/SlackMessageSender.cs
+++ b/Runtime/Reporters/Slack/SlackMessageSender.cs
@@ -20,7 +20,7 @@ namespace DeNA.Anjin.Reporters.Slack
         /// Post report log message, stacktrace and screenshot
         /// </summary>
         /// <param name="slackToken">Slack API token</param>
-        /// <param name="slackChannel">Slack channel ID or name to send notification</param>
+        /// <param name="slackChannel">Slack channel ID or name to post</param>
         /// <param name="mentionSubTeamIDs">Subteam IDs to mention</param>
         /// <param name="addHereInSlackMessage">Whether adding @here or not</param>
         /// <param name="lead">Lead text (out of attachment)</param>

--- a/Runtime/Reporters/SlackReporter.cs
+++ b/Runtime/Reporters/SlackReporter.cs
@@ -21,9 +21,7 @@ namespace DeNA.Anjin.Reporters
         public string slackToken;
 
         /// <summary>
-        /// Comma-separated Slack channel's IDs (e.g., "C123456") to post. If omitted, it will not be sent.
-        /// In Slack API v1, could specify a channel name.
-        /// However, in v2, can't upload screenshots by channel name.
+        /// Comma-separated Slack channel name (e.g., "#test") or ID (e.g., "C123456") to post. If omitted, it will not be sent.
         /// </summary>
         public string slackChannels;
 

--- a/Tests/Runtime/TestDoubles/SpySlackAPI.cs
+++ b/Tests/Runtime/TestDoubles/SpySlackAPI.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 DeNA Co., Ltd.
+// Copyright (c) 2023-2025 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
 using System.Collections.Generic;
@@ -13,7 +13,8 @@ namespace DeNA.Anjin.TestDoubles
     {
         public List<Dictionary<string, string>> Arguments { get; } = new List<Dictionary<string, string>>();
 
-        private readonly SlackResponse _successResponse = SlackResponse.FromJson("{\"ok\":true,\"ts\":\"1\"}");
+        private readonly SlackResponse _successResponse =
+            SlackResponse.FromJson("{\"ok\":true,\"channel\":\"CHANNEL\",\"ts\":\"1\"}");
 
         public override async UniTask<SlackResponse> Post(string token, string channel, string text, string message,
             Color color, string ts = null)


### PR DESCRIPTION
### Before

Slack channels must be specified by channel ID.

This constraint was added in #135 

### After

Slack channel can be specified channel name or ID.

Got the channel ID from the post API response, so I used this to post the screenshot.

Test results: https://github.com/nowsprinting/Anjin/actions/runs/13395260447

### Priority

Low.
I want to release after merging this and existing PR.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).