### PR TITLE
Fix to Hide from "Add Component" picker

### DIFF
--- a/Tests/Runtime/TestComponents/OutGameTutorialButton.cs
+++ b/Tests/Runtime/TestComponents/OutGameTutorialButton.cs
@@ -7,7 +7,7 @@ using Button = UnityEngine.UI.Button;
 namespace DeNA.Anjin.TestComponents
 {
     [RequireComponent(typeof(Button))]
-    [AddComponentMenu("")] // Hide from "Add Component" picker
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     public class OutGameTutorialButton : MonoBehaviour
     {
         private static bool s_tutorialCompleted;

--- a/Tests/Runtime/TestDoubles/SpyAgent.cs
+++ b/Tests/Runtime/TestDoubles/SpyAgent.cs
@@ -5,14 +5,12 @@ using System;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using DeNA.Anjin.Agents;
-using UnityEngine;
 
 namespace DeNA.Anjin.TestDoubles
 {
     /// <summary>
     /// Spy agent that count the number of called times
     /// </summary>
-    [AddComponentMenu("")]
     // ReSharper disable once RequiredBaseTypesIsNotInherited
     public class SpyAgent : AbstractAgent
     {

--- a/Tests/Runtime/TestDoubles/SpyAliveCountAgent.cs
+++ b/Tests/Runtime/TestDoubles/SpyAliveCountAgent.cs
@@ -4,14 +4,12 @@
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using DeNA.Anjin.Agents;
-using UnityEngine;
 
 namespace DeNA.Anjin.TestDoubles
 {
     /// <summary>
     /// Spy agent that count the number of alive instances.
     /// </summary>
-    [AddComponentMenu("")]
     // ReSharper disable once RequiredBaseTypesIsNotInherited
     public class SpyAliveCountAgent : AbstractAgent
     {

--- a/Tests/Runtime/TestDoubles/SpyButton.cs
+++ b/Tests/Runtime/TestDoubles/SpyButton.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 namespace DeNA.Anjin.TestDoubles
 {
     [RequireComponent(typeof(Button))]
-    [AddComponentMenu("")]
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     public class SpyButton : MonoBehaviour
     {
         public bool IsClicked { get; private set; }

--- a/Tests/Runtime/TestDoubles/StubThrowingErrorFromNotMainThreadOnClick.cs
+++ b/Tests/Runtime/TestDoubles/StubThrowingErrorFromNotMainThreadOnClick.cs
@@ -12,7 +12,7 @@ namespace DeNA.Anjin.TestDoubles
     /// <summary>
     /// A test stub throw errors when clicked
     /// </summary>
-    [AddComponentMenu("")]
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     public class StubThrowingErrorFromNotMainThreadOnClick : MonoBehaviour, IPointerClickHandler
     {
         public void OnPointerClick(PointerEventData eventData)

--- a/Tests/Runtime/TestDoubles/StubThrowingErrorOnClick.cs
+++ b/Tests/Runtime/TestDoubles/StubThrowingErrorOnClick.cs
@@ -11,7 +11,7 @@ namespace DeNA.Anjin.TestDoubles
     /// <summary>
     /// A test stub throw errors when clicked
     /// </summary>
-    [AddComponentMenu("")]
+    [AddComponentMenu("/")] // Hide from "Add Component" picker
     public class StubThrowingErrorOnClick : MonoBehaviour, IPointerClickHandler
     {
         public void OnPointerClick(PointerEventData eventData)


### PR DESCRIPTION
### Changes

Due to a regression in Unity (not sure when this started), specifying "" for name no longer hides, so I changed it to "/".

Bug reported: IN-96428

see: https://docs.unity3d.com/ScriptReference/AddComponentMenu-ctor.html

### Priority

Low


<!-- write content here -->

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).