### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -150,6 +150,26 @@ file_header_template = Copyright (c) 2023-${CurrentDate.Year} DeNA Co., Ltd.\nTh
 # RS0016: Only enable if API files are present
 dotnet_public_api_analyzer.require_api_files = true
 
+# IDE0055: Fix formatting
+# Workaround for https://github.com/dotnet/roslyn/issues/70570
+dotnet_diagnostic.IDE0055.severity = warning
+
+# https://github.com/dotnet/roslyn-analyzers/issues/7436 - False positives from valid GetDeclaredSymbol calls
+dotnet_diagnostic.RS1039.severity = none
+
+# These xUnit analyzers were disabled temporarily to let us move to the
+# new xUnit and get past several component governance issues. The
+# following issue tracks enabling them
+#
+# https://github.com/dotnet/roslyn/issues/75093
+dotnet_diagnostic.xUnit1012.severity = none
+dotnet_diagnostic.xUnit1030.severity = none
+dotnet_diagnostic.xUnit1031.severity = none
+dotnet_diagnostic.xUnit2005.severity = none
+dotnet_diagnostic.xUnit2020.severity = none
+dotnet_diagnostic.xUnit2023.severity = none
+dotnet_diagnostic.xUnit2029.severity = none
+
 # CSharp code style settings:
 [*.cs]
 # Newline settings
@@ -160,6 +180,9 @@ csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
+csharp_place_type_attribute_on_same_line = false
+csharp_place_method_attribute_on_same_line = false
+csharp_place_accessorholder_attribute_on_same_line = false
 csharp_place_field_attribute_on_same_line = false
 
 # Indentation preferences
@@ -232,12 +255,30 @@ csharp_preserve_single_line_statements = true
 # IDE0060: Remove unused parameter
 dotnet_diagnostic.IDE0060.severity = warning
 
+# ReSharper comment alignment
+resharper_csharp_int_align_comments = true
+
+# Some values of the enum are not processed inside 'switch' statement and are handled via default section
+resharper_switch_statement_handles_some_known_enum_values_with_default_highlighting = warning
+
+# BannedApiAnalyzers
+dotnet_diagnostic.RS0030.severity = error
+
 # Suppress C#8.0+ syntax sugar (for under Unity 2020.2 compatibility)
 # See: https://www.jetbrains.com/help/resharper/Reference__Code_Inspections_CSHARP.html
 resharper_convert_to_using_declaration_highlighting = none
 resharper_convert_to_null_coalescing_compound_assignment_highlighting = none
 resharper_merge_into_logical_pattern_highlighting = none
 resharper_use_negated_pattern_in_is_expression_highlighting = none
+
+# Unity Test Framework
+[**/Tests/**/*.cs]
+
+# Access to a static member of a type via a derived type (e.g., NUnit.Framework.Is)
+resharper_access_to_static_member_via_derived_type_highlighting = none
+
+# NUnit2045: Use Assert.Multiple
+dotnet_diagnostic.NUnit2045.severity = none
 
 [src/{Compilers,ExpressionEvaluator,Scripting}/**Test**/*.{cs,vb}]
 
@@ -291,3 +332,20 @@ dotnet_diagnostic.IDE2006.severity = warning
 # CA1822: Make member static
 # There is a risk of accidentally breaking an internal API that partners rely on though IVT.
 dotnet_code_quality.CA1822.api_surface = private
+
+[**/{ExternalAccess}/**/*.{cs,vb}]
+
+# RS0016: Only enable if API files are present
+dotnet_public_api_analyzer.require_api_files = true
+
+dotnet_diagnostic.RS0051.severity = error
+dotnet_diagnostic.RS0052.severity = error
+dotnet_diagnostic.RS0053.severity = error
+dotnet_diagnostic.RS0054.severity = error
+dotnet_diagnostic.RS0055.severity = error
+dotnet_diagnostic.RS0056.severity = error
+dotnet_diagnostic.RS0057.severity = error
+dotnet_diagnostic.RS0058.severity = error
+dotnet_diagnostic.RS0059.severity = error
+dotnet_diagnostic.RS0060.severity = error
+dotnet_diagnostic.RS0061.severity = error

--- a/Editor/Definitions/AssemblyDefinition.cs
+++ b/Editor/Definitions/AssemblyDefinition.cs
@@ -17,12 +17,12 @@ namespace DeNA.Anjin.Editor.Definitions
     [SuppressMessage("ReSharper", "MissingXmlDoc")]
     public class AssemblyDefinition
     {
-        public bool allowUnsafeCode = false; //Optional. Defaults to false.
-        public bool autoReferenced = true; //Optional. Defaults to true.
-        public string[] defineConstraints; // Optional. The symbols that serve as constraints. Can be empty.
-        public string[] excludePlatforms; // Optional. The platform name strings to exclude or an empty array.
-        public string[] includePlatforms; // Optional. The platform name strings to exclude or an empty array.
-        public string name; // Required.
+        public bool allowUnsafeCode = false;    //Optional. Defaults to false.
+        public bool autoReferenced = true;      //Optional. Defaults to true.
+        public string[] defineConstraints;      // Optional. The symbols that serve as constraints. Can be empty.
+        public string[] excludePlatforms;       // Optional. The platform name strings to exclude or an empty array.
+        public string[] includePlatforms;       // Optional. The platform name strings to exclude or an empty array.
+        public string name;                     // Required.
         public bool noEngineReferences = false; // Optional. Defaults to false.
 
         public string[] optionalUnityReferences;

--- a/Editor/UI/Reporters/CompositeReporterEditor.cs
+++ b/Editor/UI/Reporters/CompositeReporterEditor.cs
@@ -48,7 +48,7 @@ namespace DeNA.Anjin.Editor.UI.Reporters
                 // XXX: Dont use discarded parameter to treat Unity 2019.x
                 // ReSharper disable UnusedParameter.Local
                 drawElementCallback = (rect, index, active, focused) =>
-                // ReSharper restore UnusedParameter.Local
+                    // ReSharper restore UnusedParameter.Local
                 {
                     var elemProp = _reportersProp.GetArrayElementAtIndex(index);
                     EditorGUI.PropertyField(rect, elemProp, _reporterGUIContent);
@@ -63,7 +63,7 @@ namespace DeNA.Anjin.Editor.UI.Reporters
 
             EditorGUILayout.PropertyField(_descriptionProp, _descriptionGUIContent);
             _reorderableList.DoLayoutList();
-            
+
             serializedObject.ApplyModifiedProperties();
         }
     }

--- a/Editor/UI/Reporters/SlackReporterEditor.cs
+++ b/Editor/UI/Reporters/SlackReporterEditor.cs
@@ -190,7 +190,8 @@ namespace DeNA.Anjin.Editor.UI.Reporters
 
             EditorGUI.BeginDisabledGroup(!_postOnNormallyProp.boolValue);
             EditorGUILayout.PropertyField(_mentionSubTeamIDsOnNormallyProp, _mentionSubTeamIDsOnNormallyGUIContent);
-            EditorGUILayout.PropertyField(_addHereInSlackMessageOnNormallyProp, _addHereInSlackMessageOnNormallyGUIContent);
+            EditorGUILayout.PropertyField(_addHereInSlackMessageOnNormallyProp,
+                _addHereInSlackMessageOnNormallyGUIContent);
             EditorGUILayout.PropertyField(_leadTextOnNormallyProp, _leadTextOnNormallyGUIContent);
             EditorGUILayout.PropertyField(_messageBodyTemplateOnNormallyProp, _messageBodyTemplateOnNormallyGUIContent);
             EditorGUILayout.PropertyField(_colorOnNormallyProp, _colorOnNormallyGUIContent);

--- a/Runtime/Agents/UGUIMonkeyAgent.cs
+++ b/Runtime/Agents/UGUIMonkeyAgent.cs
@@ -137,7 +137,7 @@ namespace DeNA.Anjin.Agents
                     : null,
                 Operators = new IOperator[]
                 {
-                    new UGUIClickOperator(), //
+                    new UGUIClickOperator(),                                           //
                     new UGUIClickAndHoldOperator(holdMillis: touchAndHoldDelayMillis), //
                     new UGUITextInputOperator(
                         randomStringParams: GetRandomStringParameters,

--- a/Runtime/Reporters/AbstractReporter.cs
+++ b/Runtime/Reporters/AbstractReporter.cs
@@ -17,7 +17,8 @@ namespace DeNA.Anjin.Reporters
         /// <summary>
         /// Description about this agent instance.
         /// </summary>
-        [Multiline] public string description;
+        [Multiline]
+        public string description;
 #endif
 
         /// <summary>

--- a/Runtime/Reporters/CompositeReporter.cs
+++ b/Runtime/Reporters/CompositeReporter.cs
@@ -31,8 +31,7 @@ namespace DeNA.Anjin.Reporters
             await UniTask.WhenAll(
                 reporters
                     .Where(r => r != this && r != null)
-                    .Select(
-                        r => r.PostReportAsync(message, stackTrace, exitCode, cancellationToken)
+                    .Select(r => r.PostReportAsync(message, stackTrace, exitCode, cancellationToken)
                     )
             );
         }

--- a/Runtime/Settings/ScenePickerAttribute.cs
+++ b/Runtime/Settings/ScenePickerAttribute.cs
@@ -18,7 +18,8 @@ namespace DeNA.Anjin.Settings
         /// 
         /// Set If a label different from the field name is specified.
         /// </summary>
-        [CanBeNull] public readonly string Label;
+        [CanBeNull]
+        public readonly string Label;
 
         /// <summary>
         /// Constructor

--- a/Tests/Runtime/Agents/ErrorHandlerAgentTest.cs
+++ b/Tests/Runtime/Agents/ErrorHandlerAgentTest.cs
@@ -197,9 +197,9 @@ namespace DeNA.Anjin.Agents
             sut.OverwriteByCommandLineArguments(new StubArguments()
             {
                 _handleException = new StubArgument<bool>(), // Not captured
-                _handleError = new StubArgument<bool>(), // Not captured
-                _handleAssert = new StubArgument<bool>(), // Not captured
-                _handleWarning = new StubArgument<bool>(), // Not captured
+                _handleError = new StubArgument<bool>(),     // Not captured
+                _handleAssert = new StubArgument<bool>(),    // Not captured
+                _handleWarning = new StubArgument<bool>(),   // Not captured
             });
             Assert.That(sut.handleException, Is.EqualTo(HandlingBehavior.TerminateAutopilot));
             Assert.That(sut.handleError, Is.EqualTo(HandlingBehavior.TerminateAutopilot));

--- a/Tests/Runtime/Agents/OneTimeAgentTest.cs
+++ b/Tests/Runtime/Agents/OneTimeAgentTest.cs
@@ -139,7 +139,7 @@ namespace DeNA.Anjin.Agents
             await Launcher.LaunchAutopilotAsync(settings);
 
             sut = ScriptableObject.CreateInstance<OneTimeAgent>(); // Reload because domain reloaded
-            Assert.That(sut.WasExecuted, Is.False); // was reset
+            Assert.That(sut.WasExecuted, Is.False);                // was reset
         }
     }
 }

--- a/Tests/Runtime/Agents/UGUIMonkeyAgentTest.cs
+++ b/Tests/Runtime/Agents/UGUIMonkeyAgentTest.cs
@@ -115,7 +115,7 @@ namespace DeNA.Anjin.Agents
         public async Task Run_TimeoutExceptionOccurred_AutopilotFailed()
         {
             var agent = CreateAgent();
-            agent.lifespanSec = 0; // Expect indefinite execution
+            agent.lifespanSec = 0;                             // Expect indefinite execution
             agent.secondsToErrorForNoInteractiveComponent = 1; // TimeoutException occurred after 1 second
 
             var spyTerminatable = new SpyTerminatable();
@@ -142,7 +142,7 @@ namespace DeNA.Anjin.Agents
         public async Task Run_InfiniteLoopExceptionOccurred_AutopilotFailed()
         {
             var agent = CreateAgent();
-            agent.lifespanSec = 0; // Expect indefinite execution
+            agent.lifespanSec = 0;                  // Expect indefinite execution
             agent.bufferLengthForDetectLooping = 5; // Enable infinite loop detection
             // Note: The loop is detected immediately because there are only two active buttons on the test scene.
 

--- a/Tests/Runtime/AutopilotTest.cs
+++ b/Tests/Runtime/AutopilotTest.cs
@@ -190,7 +190,7 @@ namespace DeNA.Anjin
             await Launcher.LaunchAutopilotAsync(autopilotSettings);
 
             Assert.That(spyLogger.Logs, Does.Contain((LogType.Log, "Launched Autopilot"))); // using spy logger
-            LogAssert.NoUnexpectedReceived(); // not write to console
+            LogAssert.NoUnexpectedReceived();                                               // not write to console
         }
 
         [Test]

--- a/Tests/Runtime/Reporters/JUnitXmlReporterTest.cs
+++ b/Tests/Runtime/Reporters/JUnitXmlReporterTest.cs
@@ -96,7 +96,7 @@ namespace DeNA.Anjin.Reporters
             var expected = new XElement("testsuite",
                 new XAttribute("name", name),
                 new XAttribute("tests", 1),
-                new XAttribute("id", 0), // Note: fixed value
+                new XAttribute("id", 0),       // Note: fixed value
                 new XAttribute("disabled", 0), // Note: fixed value
                 new XAttribute("errors", 0),
                 new XAttribute("failures", 0),
@@ -123,7 +123,7 @@ namespace DeNA.Anjin.Reporters
             var expected = new XElement("testsuite",
                 new XAttribute("name", name),
                 new XAttribute("tests", 1),
-                new XAttribute("id", 0), // Note: fixed value
+                new XAttribute("id", 0),       // Note: fixed value
                 new XAttribute("disabled", 0), // Note: fixed value
                 new XAttribute("errors", 1),
                 new XAttribute("failures", 0),
@@ -150,7 +150,7 @@ namespace DeNA.Anjin.Reporters
             var expected = new XElement("testsuite",
                 new XAttribute("name", name),
                 new XAttribute("tests", 1),
-                new XAttribute("id", 0), // Note: fixed value
+                new XAttribute("id", 0),       // Note: fixed value
                 new XAttribute("disabled", 0), // Note: fixed value
                 new XAttribute("errors", 0),
                 new XAttribute("failures", 1),

--- a/Tests/Runtime/Reporters/SlackReporterTest.cs
+++ b/Tests/Runtime/Reporters/SlackReporterTest.cs
@@ -82,9 +82,9 @@ namespace DeNA.Anjin.Reporters
             Assert.That(_spy.CalledList.Count, Is.EqualTo(1));
             Assert.That(_spy.CalledList[0].MentionSubTeamIDs, Is.EquivalentTo(new[] { "charlie" }));
             Assert.That(_spy.CalledList[0].AddHereInSlackMessage, Is.True);
-            Assert.That(_spy.CalledList[0].Lead, Is.EqualTo("Normally terminate lead")); // use OnNormally
+            Assert.That(_spy.CalledList[0].Lead, Is.EqualTo("Normally terminate lead"));            // use OnNormally
             Assert.That(_spy.CalledList[0].Message, Is.EqualTo("Normally terminate with message")); // use OnNormally
-            Assert.That(_spy.CalledList[0].WithScreenshot, Is.True); // use OnNormally
+            Assert.That(_spy.CalledList[0].WithScreenshot, Is.True);                                // use OnNormally
         }
 
         [Test]

--- a/Tests/Runtime/Settings/AutopilotSettingsTest.cs
+++ b/Tests/Runtime/Settings/AutopilotSettingsTest.cs
@@ -29,10 +29,10 @@ namespace DeNA.Anjin.Settings
         {
             var arguments = new StubArguments
             {
-                _lifespanSec = new StubArgument<int>(), // Not captured
-                _randomSeed = new StubArgument<string>(), // Not captured
-                _timeScale = new StubArgument<float>(), // Not captured
-                _outputRootPath = new StubArgument<string>(), // Not captured
+                _lifespanSec = new StubArgument<int>(),        // Not captured
+                _randomSeed = new StubArgument<string>(),      // Not captured
+                _timeScale = new StubArgument<float>(),        // Not captured
+                _outputRootPath = new StubArgument<string>(),  // Not captured
                 _screenshotsPath = new StubArgument<string>(), // Not captured
             };
             return arguments;

--- a/Tests/Runtime/TestDoubles/StubClickAgent.cs
+++ b/Tests/Runtime/TestDoubles/StubClickAgent.cs
@@ -18,7 +18,8 @@ namespace DeNA.Anjin.TestDoubles
         /// <summary>
         /// A name of game objects to click
         /// </summary>
-        [SerializeField] public string targetName;
+        [SerializeField]
+        public string targetName;
 
 
         /// <inheritdoc />

--- a/Tests/Runtime/TestDoubles/StubThrowingErrorFromNotMainThreadOnClick.cs
+++ b/Tests/Runtime/TestDoubles/StubThrowingErrorFromNotMainThreadOnClick.cs
@@ -17,8 +17,7 @@ namespace DeNA.Anjin.TestDoubles
     {
         public void OnPointerClick(PointerEventData eventData)
         {
-            Task.Run(
-                () => Debug.LogException(new Exception($"TEST on thread #{Thread.CurrentThread.ManagedThreadId}"))
+            Task.Run(() => Debug.LogException(new Exception($"TEST on thread #{Thread.CurrentThread.ManagedThreadId}"))
             );
         }
     }

--- a/Tests/Runtime/TestUtils/Build/CopyAssetsToResources.cs
+++ b/Tests/Runtime/TestUtils/Build/CopyAssetsToResources.cs
@@ -13,7 +13,10 @@ namespace DeNA.Anjin.TestUtils.Build
     {
         private const string TestAssetsDirectory = "Packages/com.dena.anjin/Tests/TestAssets";
         internal const string ResourcesBaseDirectory = "Assets/com.dena.anjin";
-        private static readonly string s_resourcesTestsDirectory = Path.Combine(ResourcesBaseDirectory, "Resources/Tests");
+
+        private static readonly string s_resourcesTestsDirectory =
+            Path.Combine(ResourcesBaseDirectory, "Resources/Tests");
+
         private static readonly string s_resourcesDirectory = Path.Combine(s_resourcesTestsDirectory, "TestAssets");
 
         public static string GetAssetPath(string path)


### PR DESCRIPTION
### Changes

- Update .editorconfig
  - Formatter: attributes
  - Formatter: comments indent
  - Cherry-pick from the latest Roslyn`s .editorconfig
  - Severity for `resharper_switch_statement_handles_some_known_enum_values_with_default_highlighting`
  - Severity for BannedApiAnalyzers
  - Severity for NUnit.Analyzers
  - See also: https://www.nowsprinting.com/entry/2025/04/30/080000
- Apply formatter

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).