### PR TITLE
Change UGUIPlaybackAgent to now optional (tradeoff with Unity 6000.2.6f1 and later)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: {}
+permissions: { }
 
 defaults:
   run:
@@ -30,24 +30,24 @@ jobs:
           - 2019.4.40f1
           - 2020.3.48f1
           - 2021.3.45f1
-          - 2022.3.59f1
-          - 2023.2.20f1
-          - 6000.0.41f1
+          - 2022.3.62f1
+          - 6000.0.58f1
+          - 6000.2.6f1
         depends:
           - min # use required version of dependencies
         testMode:
           - All # run tests in editor
         include:
-          - unityVersion: 6000.0.41f1
+          - unityVersion: 6000.2.6f1
             depends: latest # use latest version of dependencies
             testMode: All
             octocov: true
-          - unityVersion: 6000.0.41f1
+          - unityVersion: 6000.2.6f1
             depends: min
             testMode: Standalone  # run tests on player
 
     steps:
-      - name: Crete project for tests
+      - name: Create project for tests
         uses: nowsprinting/create-unity-project-action@fab595f04a568aa51a94b28b7202b861b0f7d8b2 # v3
         with:
           project-path: UnityProject~

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,13 @@ jobs:
         working-directory: ${{ env.CREATED_PROJECT_PATH }}
         if: ${{ matrix.depends == 'latest' }}
 
+      - name: Install Automated QA package (Unity version must be below 6000.2)
+        run: |
+          npm install -g openupm-cli
+          openupm add -f com.unity.automated-testing
+        working-directory: ${{ env.CREATED_PROJECT_PATH }}
+        if: ${{ matrix.unityVersion < '6000.2' }}
+
       - name: Set coverage assembly filters
         run: |
           assemblies=$(find ${{ env.PACKAGE_PATH }} -name "*.asmdef" | sed -e s/.*\\//\+/ | sed -e s/\\.asmdef// | sed -e s/^.*\\.Tests//)

--- a/Editor/UI/Agents/UGUIPlaybackAgentEditor.cs
+++ b/Editor/UI/Agents/UGUIPlaybackAgentEditor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2023 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
+#if ENABLE_AQA
 using System.Diagnostics.CodeAnalysis;
 using DeNA.Anjin.Agents;
 using UnityEditor;
@@ -34,3 +35,4 @@ namespace DeNA.Anjin.Editor.UI.Agents
         }
     }
 }
+#endif

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ An instance of this Agent (.asset file) can contain the following.
 > See **Anjin Annotations** below for more information.
 
 
-### UGUIPlaybackAgent
+### UGUIPlaybackAgent (optional)
 
 This is an Agent that playback uGUI operations with the Recorded Playback feature of the [Automated QA](https://docs.unity3d.com/Packages/com.unity.automated-testing@latest) package.
 
@@ -333,12 +333,13 @@ Note that the Recorded Playback function in Automated QA can record operations a
 Therefore, please be careful to record in units of Scenes.
 
 > [!IMPORTANT]  
+> UGUIPlaybackAgent is an optional functionality. To use it, you need to install the [Automated QA](https://docs.unity3d.com/Packages/com.unity.automated-testing@latest) package separately via the Package Manager window.
+> The Automated QA package development has been put on hold until further notice.
+
+> [!IMPORTANT]  
 > The Automated QA package outputs `LogType.Error` to the console when playback fails (e.g., the target Button cannot be found). The following setting is required to detect this and terminate the autopilot.
 > 1. Add [ErrorHandlerAgent](#ErrorHandlerAgent) and set `Handle Error` to `Terminate Autopilot`.
 > 2. Add [ConsoleLogger](#ConsoleLogger) and set `Filter LogType` to `Error` or higher.
-
-> [!IMPORTANT]  
-> The Automated QA package is in the preview stage. Please note that destructive changes may occur, and the package itself may be discontinued or withdrawn.
 
 
 ### DoNothingAgent

--- a/README_ja.md
+++ b/README_ja.md
@@ -318,7 +318,7 @@ uGUIのコンポーネントをランダムに操作するAgentです。
 > 詳しくは後述の**Anjin Annotations**を参照してください。
 
 
-### UGUIPlaybackAgent
+### UGUIPlaybackAgent（オプション）
 
 [Automated QA](https://docs.unity3d.com/Packages/com.unity.automated-testing@latest)パッケージのRecorded Playback機能でレコーディングしたuGUI操作を再生するAgentです。
 
@@ -337,12 +337,13 @@ Automated QAによる操作のレコーディングは、Unityエディターの
 従って、レコーディングはScene単位に区切って行なうようご注意ください。
 
 > [!IMPORTANT]  
+> UGUIPlaybackAgent はオプション機能です。使用するには、Package Manager ウィンドウから [Automated QA](https://docs.unity3d.com/Packages/com.unity.automated-testing@latest) パッケージを別途インストールする必要があります。
+> Automated QA パッケージの開発は、追って通知があるまで保留されています。
+
+> [!IMPORTANT]  
 > Automated QAパッケージは、再生に失敗（対象のボタンが見つからないなど）したときコンソールに `LogType.Error` を出力します。これを検知してオートパイロットを停止するには、次の設定が必要です。
 > 1. [ErrorHandlerAgent](#ErrorHandlerAgent) を追加し、`Handle Error` を `Terminate Autopilot` に設定します
 > 2. [ConsoleLogger](#ConsoleLogger) を追加し、`Filter LogType` に `Error` 以上を設定します
-
-> [!IMPORTANT]  
-> Automated QAパッケージはプレビュー段階のため、破壊的変更や、パッケージ自体の開発中止・廃止もありえる点、ご注意ください。
 
 
 ### DoNothingAgent

--- a/Runtime/Agents/UGUIPlaybackAgent.cs
+++ b/Runtime/Agents/UGUIPlaybackAgent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2023 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
+#if ENABLE_AQA
 using System;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
@@ -111,3 +112,4 @@ namespace DeNA.Anjin.Agents
         }
     }
 }
+#endif

--- a/Runtime/DeNA.Anjin.asmdef
+++ b/Runtime/DeNA.Anjin.asmdef
@@ -25,6 +25,11 @@
             "name": "com.unity.multiplayer.playmode",
             "expression": "",
             "define": "ENABLED_MPPM"
+        },
+        {
+            "name": "com.unity.automated-testing",
+            "expression": "",
+            "define": "ENABLE_AQA"
         }
     ],
     "noEngineReferences": false

--- a/Tests/Runtime/Agents/UGUIEmergencyExitAgentTest.cs
+++ b/Tests/Runtime/Agents/UGUIEmergencyExitAgentTest.cs
@@ -203,7 +203,7 @@ namespace DeNA.Anjin.Agents
                 await UniTask.NextFrame();
 
                 var emergencyButton = AttachEmergencyExitAnnotation();
-                await UniTask.Delay(200);
+                await UniTask.Delay(500);
 
                 Assert.That(emergencyButton.IsClicked, Is.True, "Clicked button with EmergencyExit annotation");
                 Assert.That(task.Status, Is.EqualTo(UniTaskStatus.Pending), "Keep agent running");

--- a/Tests/Runtime/Agents/UGUIPlaybackAgentTest.cs
+++ b/Tests/Runtime/Agents/UGUIPlaybackAgentTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2023 DeNA Co., Ltd.
 // This software is released under the MIT License.
 
+#if ENABLE_AQA
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
@@ -131,3 +132,4 @@ namespace DeNA.Anjin.Agents
         }
     }
 }
+#endif

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "changelogUrl": "https://github.com/DeNA/Anjin/releases",
   "dependencies": {
     "com.cysharp.unitask": "2.3.3",
-    "com.nowsprinting.test-helper.monkey": "0.15.1",
-    "com.unity.automated-testing": "0.8.1-preview.2"
+    "com.nowsprinting.test-helper.monkey": "0.15.1"
   },
   "displayName": "Anjin",
   "documentationUrl": "https://github.com/DeNA/Anjin/blob/master/README.md",


### PR DESCRIPTION
### Changes

Change com.unity.automated-testing package to now optional.

### Reason

In Unity 6000.2.6f1, the built-in com.unity.test-framework package has been upgraded to v1.6.0, which causes the following compilation error:

```
Library/PackageCache/com.unity.automated-testing@1a0be522046f/Editor/Cloud/CloudTestPipeline.cs(59,28): error CS0104: 'TestMode' is an ambiguous reference between 'UnityEditor.TestTools.TestRunner.Api.TestMode' and 'UnityEngine.TestTools.TestMode'
```

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).